### PR TITLE
Feat(#28): 상영 날짜 조회 구현

### DIFF
--- a/src/main/java/cinebox/common/exception/ExceptionMessage.java
+++ b/src/main/java/cinebox/common/exception/ExceptionMessage.java
@@ -13,33 +13,30 @@ public enum ExceptionMessage {
 	ALREADY_EXIST_USER("사용 중인 아이디 입니다.", HttpStatus.BAD_REQUEST, "Already Exist UserId"),
 	NOT_AUTHORIZED_USER("토큰 정보와 일치하는 사용자가 아닙니다.", HttpStatus.FORBIDDEN, "Not Authorized User"),
 	ACCESS_DENIED_USER("해당 리소스에 접근할 권한이 없습니다.", HttpStatus.FORBIDDEN, "Access Denied"),
-	
+
 	// movie
 	NOT_FOUND_MOVIE("유효하지 않은 MovieId 입니다.", HttpStatus.NOT_FOUND, "Not Found MovieId"),
 	DUPLICATED_MOVIE("이미 존재하는 영화입니다.", HttpStatus.CONFLICT, "Conflict Title and ReleaseDate"),
-  MOVIE_DELETE_FAILED("영화 삭제에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR, "Failed to Delete Movie"),
-	
-	// booking- screen
-	NOT_FOUND_SCREEN("유효하지 않은 ScreenId 입니다.", HttpStatus.NOT_FOUND, "Not Found ScreenId"),
+	MOVIE_DELETE_FAILED("영화 삭제에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR, "Failed to Delete Movie"),
 
 	// booking- seat
 	NOT_FOUND_SEAT("유효하지 않은 SeatId 입니다.", HttpStatus.NOT_FOUND, "Not Found SeatId"),
 	SEAT_ALREADY_BOOKED("이미 예약된 좌석입니다.", HttpStatus.BAD_REQUEST, "Seat Already Booked"),
-	
+
 	// review
 	NOT_FOUND_REVIEW("유효하지 않은 ReviewId 입니다.", HttpStatus.NOT_FOUND, "Not Found ReviewId"),
-	
+
 	// validation error
 	VALIDATION_ERROR("빈 값을 허용하지 않습니다.", HttpStatus.BAD_REQUEST, "Validation Error"),
-	
+
 	// auditorium
 	NOT_FOUND_AUDITORIUM("유효하지 않은 AuditoriumId 입니다.", HttpStatus.NOT_FOUND, "Not Found AuditoriumId"),
-	
+
 	// screen
 	NOT_FOUND_SCREEN("유효하지 않은 ScreenId 입니다.", HttpStatus.NOT_FOUND, "Not Found ScreenId"),
-	
+
 	// booking
-  SEAT_NOT_FOUND("좌석을 찾을 수 없습니다.", HttpStatus.NOT_FOUND, "Not Found Seat"),
+	SEAT_NOT_FOUND("좌석을 찾을 수 없습니다.", HttpStatus.NOT_FOUND, "Not Found Seat"),
 	SCREEN_NOT_FOUND("상영 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND, "Not Found Screen for Booking");
 
 	private final String message;

--- a/src/main/java/cinebox/controller/MovieController.java
+++ b/src/main/java/cinebox/controller/MovieController.java
@@ -1,5 +1,6 @@
 package cinebox.controller;
 
+import java.time.LocalDate;
 import java.util.List;
 
 import org.springframework.http.ResponseEntity;
@@ -47,6 +48,13 @@ public class MovieController {
 	@GetMapping("/{movieId}")
 	public ResponseEntity<MovieResponse> getMovie(@PathVariable("movieId") Long movieId) {
 		return ResponseEntity.ok(movieService.getMovie(movieId));
+	}
+	
+	// 특정 영화 상영 날짜 목록 조회
+	@GetMapping("/{movieId}/dates")
+	public ResponseEntity<List<LocalDate>> getAvailableDatesForMovie(@PathVariable("movieId") Long movieId) {
+		List<LocalDate> dates = movieService.getAvailableDatesForMovie(movieId);
+		return ResponseEntity.ok(dates);
 	}
 	
 	//TODO: s3 연동하여 이미지 처리

--- a/src/main/java/cinebox/service/MovieService.java
+++ b/src/main/java/cinebox/service/MovieService.java
@@ -1,5 +1,6 @@
 package cinebox.service;
 
+import java.time.LocalDate;
 import java.util.List;
 
 import cinebox.dto.request.MovieRequest;
@@ -16,6 +17,9 @@ public interface MovieService {
 	
 	// 특정 영화 조회
 	MovieResponse getMovie(Long movieId);
+
+	// 특정 영화 상영 날짜 목록 조회
+	List<LocalDate> getAvailableDatesForMovie(Long movieId);
 	
 	// update
 	// 영화 정보 수정

--- a/src/main/java/cinebox/service/MovieServiceImpl.java
+++ b/src/main/java/cinebox/service/MovieServiceImpl.java
@@ -1,7 +1,9 @@
 package cinebox.service;
 
+import java.time.LocalDate;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.springframework.security.core.Authentication;
@@ -12,10 +14,10 @@ import cinebox.common.enums.MovieStatus;
 import cinebox.common.exception.movie.DuplicatedMovieException;
 import cinebox.common.exception.movie.MovieDeleteFailedException;
 import cinebox.common.exception.movie.NotFoundMovieException;
-import cinebox.common.exception.user.NoAuthorizedUserException;
 import cinebox.dto.request.MovieRequest;
 import cinebox.dto.response.MovieResponse;
 import cinebox.entity.Movie;
+import cinebox.entity.Screen;
 import cinebox.repository.MovieRepository;
 import lombok.RequiredArgsConstructor;
 
@@ -73,6 +75,21 @@ public class MovieServiceImpl implements MovieService {
 			throw NotFoundMovieException.EXCEPTION;
 		}
 		return MovieResponse.from(movie);
+	}
+	
+	// 특정 영화 상영 날짜 목록 조회
+	@Override
+	public List<LocalDate> getAvailableDatesForMovie(Long movieId) {
+		Movie movie = movieRepository.findById(movieId)
+				.orElseThrow(() -> NotFoundMovieException.EXCEPTION);
+		
+		List<Screen> screens = movie.getScreens();
+		
+		Set<LocalDate> dateSet = screens.stream()
+				.map(screen -> screen.getStartTime().toLocalDate())
+				.collect(Collectors.toSet());
+		
+		return dateSet.stream().sorted().collect(Collectors.toList());
 	}
 
 	// 영화 정보 수정


### PR DESCRIPTION
## #️⃣연관된 이슈

> #28 

## 📝작업 내용

> 특정 영화에 대한 상영일 조회
> 영화 상영정보(Screen)의 상영 시작 시간(StartTime)을 조회하고, 상영일자만 추출하여 중복을 제거
> 날짜 리스트를 오름차순 정렬
> 날짜 정보만 필요하기 때문에 별도의 Response 구조를 갖도록 구현하지 않음

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
