### PR TITLE
Feat(#44): 특정 영화의 날짜별 상영 정보 조회

### DIFF
--- a/src/main/java/cinebox/controller/MovieController.java
+++ b/src/main/java/cinebox/controller/MovieController.java
@@ -3,6 +3,7 @@ package cinebox.controller;
 import java.time.LocalDate;
 import java.util.List;
 
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
@@ -18,6 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import cinebox.dto.request.MovieRequest;
 import cinebox.dto.response.MovieResponse;
+import cinebox.dto.response.ScreenResponse;
 import cinebox.dto.validation.CreateGroup;
 import cinebox.service.MovieService;
 import lombok.RequiredArgsConstructor;
@@ -73,5 +75,14 @@ public class MovieController {
 	public ResponseEntity<Void> deleteMovie(@PathVariable("movieId") Long movieId) {
 		movieService.deleteMovie(movieId);
 		return ResponseEntity.noContent().build();
+	}
+    
+    // 특정 영화의 날짜별 상영 정보 조회
+    @GetMapping("/{movieId}/screens")
+    public ResponseEntity<List<ScreenResponse>> getScreensByDate(
+    		@PathVariable("movieId") Long movieId,
+    		@RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
+    	List<ScreenResponse> responses = movieService.getScreensByDate(movieId, date);
+		return ResponseEntity.ok(responses);
 	}
 }

--- a/src/main/java/cinebox/repository/ScreenRepository.java
+++ b/src/main/java/cinebox/repository/ScreenRepository.java
@@ -17,4 +17,7 @@ public interface ScreenRepository extends JpaRepository<Screen, Long> {
 
 	// 현재 스크린은 제외하고, 상영관 내 시간 겹침 검사
 	List<Screen> findByAuditoriumAndScreenIdNotAndStartTimeLessThanAndEndTimeGreaterThan(Auditorium auditorium, Long screenId, LocalDateTime endTime, LocalDateTime startTime);
+
+	// 특정 날짜 하루동안의 상영 정보 조회
+	List<Screen> findByMovie_MovieIdAndStartTimeBetween(Long movieId, LocalDateTime startOfDay, LocalDateTime endOfDay);
 }

--- a/src/main/java/cinebox/service/MovieService.java
+++ b/src/main/java/cinebox/service/MovieService.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import cinebox.dto.request.MovieRequest;
 import cinebox.dto.response.MovieResponse;
+import cinebox.dto.response.ScreenResponse;
 
 public interface MovieService {
 	// create
@@ -20,6 +21,9 @@ public interface MovieService {
 
 	// 특정 영화 상영 날짜 목록 조회
 	List<LocalDate> getAvailableDatesForMovie(Long movieId);
+	
+    // 특정 영화의 날짜별 상영 정보 조회
+	List<ScreenResponse> getScreensByDate(Long movieId, LocalDate date);
 	
 	// update
 	// 영화 정보 수정


### PR DESCRIPTION
## #️⃣연관된 이슈

#44 

## 📝작업 내용

- 쿼리 파라미터를 통해 date=yyyy-MM-dd 를 통해 특정 영화의 날짜별 상영 정보 목록을 조회
- 요청 날짜를 통해 해당 날짜와 다음 날 사이에 존재하는 시간대의 상영을 조회함

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
