### PR TITLE
Fix(#51): 영화 데이터 범위 조정

### DIFF
--- a/src/main/java/cinebox/entity/Movie.java
+++ b/src/main/java/cinebox/entity/Movie.java
@@ -13,6 +13,7 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
@@ -36,13 +37,14 @@ public class Movie extends BaseTimeEntity {
 	private String title;
 
 	// 줄거리 (description)
+	@Lob
 	private String plot;
 
 	private String director;
 	private String actor;
 	private String genre;
 
-	@Column(name = "poster_image_url")
+	@Column(name = "poster_image_url", length = 500)
 	private String posterImageUrl;
 
 	@Column(name = "release_date")

--- a/src/main/java/cinebox/service/MovieBatchService.java
+++ b/src/main/java/cinebox/service/MovieBatchService.java
@@ -213,6 +213,7 @@ public class MovieBatchService {
 	private String extractActorNames(KmdbResponse.Result result) {
 	    if (result == null || result.actors() == null || result.actors().actor().isEmpty()) return null;
 	    return result.actors().actor().stream()
+	    		.limit(6)	// 최대 6개의 데이터만 허용  
 	    		.map(KmdbResponse.Actor::actorNm)
 	    		.collect(Collectors.joining(", "));
 	}


### PR DESCRIPTION
## #️⃣연관된 이슈

#51 

## 📝작업 내용

- 영화 줄거리(plot) 데이터 TEXT 타입으로 전환
- 영화 포스터 URL 길이 500자로 길이 조정
- 영화 배우 조회 시, 리스트에서 최대 6명만 조회

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
