### PR TITLE
Feat(#17): 예매 조회 기능 구현

### DIFF
--- a/src/main/java/cinebox/common/exception/user/NoAuthorizedUserException.java
+++ b/src/main/java/cinebox/common/exception/user/NoAuthorizedUserException.java
@@ -7,6 +7,6 @@ public class NoAuthorizedUserException extends BaseException {
 	public static final BaseException EXCEPTION = new NoAuthorizedUserException();
 	
 	private NoAuthorizedUserException() {
-		super(ExceptionMessage.NOT_AUTHORIZED_USER);
+		super(ExceptionMessage.ACCESS_DENIED_USER);
 	}
 }

--- a/src/main/java/cinebox/controller/BookingController.java
+++ b/src/main/java/cinebox/controller/BookingController.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -36,5 +37,12 @@ public class BookingController {
 	public ResponseEntity<List<TicketResponse>> getMyBookings() {
 		List<TicketResponse> responses = bookingService.getMyBookings();
 		return ResponseEntity.ok(responses);
+	}
+	
+	// 특정 예매 조회
+	@GetMapping("/{bookingId}")
+	public ResponseEntity<TicketResponse> getBooking(@PathVariable("bookingId") Long bookingId) {
+		TicketResponse response = bookingService.getBooking(bookingId);
+		return ResponseEntity.ok(response);
 	}
 }

--- a/src/main/java/cinebox/dto/response/TicketResponse.java
+++ b/src/main/java/cinebox/dto/response/TicketResponse.java
@@ -17,9 +17,11 @@ public record TicketResponse(
 		Long auditoriumId,
 		String movieTitle,
 		String auditoriumName,
+		String posterImageUrl,
 		BigDecimal totPrice,
 		List<String> seatNumbers,
 		LocalDateTime screenStartTime,
+		LocalDateTime screenEndTime,
 		LocalDateTime bookingAt
 ) {
 	public static TicketResponse from(Booking booking) {
@@ -29,6 +31,7 @@ public record TicketResponse(
 				.collect(Collectors.toList());
 
 		Screen screen = bookingSeats.get(0).getScreen();
+		String poster = screen.getMovie().getPosterImageUrl();
 
 		return new TicketResponse(
 				booking.getBookingId(),
@@ -36,9 +39,11 @@ public record TicketResponse(
 				screen.getAuditorium().getAuditoriumId(),
 				screen.getMovie().getTitle(),
 				screen.getAuditorium().getName(),
+				poster,
 				booking.getTotalPrice(),
 				seatNumbers,
 				screen.getStartTime(),
+				screen.getEndTime(),
 				booking.getBookingDate());
 	}
 }

--- a/src/main/java/cinebox/security/SecurityUtil.java
+++ b/src/main/java/cinebox/security/SecurityUtil.java
@@ -3,14 +3,24 @@ package cinebox.security;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 
+import cinebox.common.exception.user.NoAuthorizedUserException;
 import cinebox.entity.User;
 
 public class SecurityUtil {
 	public static User getCurrentUser() {
 		Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-		if (auth != null || auth.getPrincipal() instanceof PrincipalDetails) {
+		if (auth != null && auth.getPrincipal() instanceof PrincipalDetails) {
 			return ((PrincipalDetails) auth.getPrincipal()).getUser();
 		}
-		return null;
+		throw NoAuthorizedUserException.EXCEPTION;
+	}
+	
+	public static boolean isAdmin() {
+		Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+		if (auth != null && auth.getPrincipal() instanceof PrincipalDetails) {
+		    return auth.getAuthorities().stream()
+		    		.anyMatch(a -> a.getAuthority().equals("ROLE_ADMIN"));
+		}
+		return false;
 	}
 }

--- a/src/main/java/cinebox/service/BookingService.java
+++ b/src/main/java/cinebox/service/BookingService.java
@@ -12,4 +12,7 @@ public interface BookingService {
 
 	// 예매 생성
 	BookingResponse createBooking(BookingRequest request);
+
+	// 특정 예매 조회
+	TicketResponse getBooking(Long bookingId);
 }

--- a/src/main/java/cinebox/service/BookingServiceImpl.java
+++ b/src/main/java/cinebox/service/BookingServiceImpl.java
@@ -9,6 +9,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import cinebox.common.enums.BookingStatus;
 import cinebox.common.exception.booking.AlreadyBookedSeatsException;
+import cinebox.common.exception.booking.NotFoundBookingException;
 import cinebox.common.exception.booking.NotFoundSeatException;
 import cinebox.common.exception.screen.NotFoundScreenException;
 import cinebox.dto.request.BookingRequest;
@@ -79,5 +80,14 @@ public class BookingServiceImpl implements BookingService {
 		bookingSeatRepository.saveAll(bookingSeats);
 		
 		return new BookingResponse(savedBooking.getBookingId(), screen.getScreenId());
+	}
+
+	// 특정 예매 조회
+	@Override
+	public TicketResponse getBooking(Long bookingId) {
+		Booking booking = bookingRepository.findById(bookingId)
+				.orElseThrow(() -> NotFoundBookingException.EXCEPTION);
+		
+		return TicketResponse.from(booking);
 	}
 }

--- a/src/main/java/cinebox/service/BookingServiceImpl.java
+++ b/src/main/java/cinebox/service/BookingServiceImpl.java
@@ -12,6 +12,7 @@ import cinebox.common.exception.booking.AlreadyBookedSeatsException;
 import cinebox.common.exception.booking.NotFoundBookingException;
 import cinebox.common.exception.booking.NotFoundSeatException;
 import cinebox.common.exception.screen.NotFoundScreenException;
+import cinebox.common.exception.user.NoAuthorizedUserException;
 import cinebox.dto.request.BookingRequest;
 import cinebox.dto.response.BookingResponse;
 import cinebox.dto.response.TicketResponse;
@@ -87,6 +88,13 @@ public class BookingServiceImpl implements BookingService {
 	public TicketResponse getBooking(Long bookingId) {
 		Booking booking = bookingRepository.findById(bookingId)
 				.orElseThrow(() -> NotFoundBookingException.EXCEPTION);
+		
+		User currentUser = SecurityUtil.getCurrentUser();
+		User bookingUser = booking.getUser();
+		
+		if (!SecurityUtil.isAdmin() && !currentUser.getUserId().equals(bookingUser.getUserId())) {
+			throw NoAuthorizedUserException.EXCEPTION;
+		}
 		
 		return TicketResponse.from(booking);
 	}


### PR DESCRIPTION
## #️⃣연관된 이슈

#17 

## 📝작업 내용

- 특정 예매에 대한 조회 구현
- 조회 시, admin이 아니거나 본인의 예매가 아니면 접근 불가

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
