### PR TITLE
Refactor(#67): Screen API 개선

### DIFF
--- a/src/main/java/cinebox/controller/MovieController.java
+++ b/src/main/java/cinebox/controller/MovieController.java
@@ -1,9 +1,7 @@
 package cinebox.controller;
 
-import java.time.LocalDate;
 import java.util.List;
 
-import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
@@ -19,7 +17,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 import cinebox.dto.request.MovieRequest;
 import cinebox.dto.response.MovieResponse;
-import cinebox.dto.response.ScreenResponse;
 import cinebox.dto.validation.CreateGroup;
 import cinebox.service.MovieService;
 import lombok.RequiredArgsConstructor;
@@ -52,13 +49,6 @@ public class MovieController {
 		return ResponseEntity.ok(movieService.getMovie(movieId));
 	}
 	
-	// 특정 영화 상영 날짜 목록 조회
-	@GetMapping("/{movieId}/dates")
-	public ResponseEntity<List<LocalDate>> getAvailableDatesForMovie(@PathVariable("movieId") Long movieId) {
-		List<LocalDate> dates = movieService.getAvailableDatesForMovie(movieId);
-		return ResponseEntity.ok(dates);
-	}
-	
 	//TODO: s3 연동하여 이미지 처리
 	// 영화 정보 수정
 	@PutMapping("/{movieId}")
@@ -75,14 +65,5 @@ public class MovieController {
 	public ResponseEntity<Void> deleteMovie(@PathVariable("movieId") Long movieId) {
 		movieService.deleteMovie(movieId);
 		return ResponseEntity.noContent().build();
-	}
-    
-    // 특정 영화의 날짜별 상영 정보 조회
-    @GetMapping("/{movieId}/screens")
-    public ResponseEntity<List<ScreenResponse>> getScreensByDate(
-    		@PathVariable("movieId") Long movieId,
-    		@RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
-    	List<ScreenResponse> responses = movieService.getScreensByDate(movieId, date);
-		return ResponseEntity.ok(responses);
 	}
 }

--- a/src/main/java/cinebox/controller/ScreenController.java
+++ b/src/main/java/cinebox/controller/ScreenController.java
@@ -20,6 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import cinebox.dto.request.ScreenRequest;
 import cinebox.dto.response.AuditoriumScreenResponse;
+import cinebox.dto.response.DateScreenResponse;
 import cinebox.dto.response.ScreenResponse;
 import cinebox.dto.validation.CreateGroup;
 import cinebox.service.ScreenService;
@@ -72,4 +73,12 @@ public class ScreenController {
     	List<AuditoriumScreenResponse> responses = screenService.getScreensByDate(movieId, date);
 		return ResponseEntity.ok(responses);
 	}
+    
+    // 모든 상영 정보 조회
+    @GetMapping("/screens")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    public ResponseEntity<List<DateScreenResponse>> getAllScreens() {
+    	List<DateScreenResponse> responses = screenService.getAllScreens();
+    	return ResponseEntity.ok(responses);
+    }
 }

--- a/src/main/java/cinebox/controller/ScreenController.java
+++ b/src/main/java/cinebox/controller/ScreenController.java
@@ -81,4 +81,12 @@ public class ScreenController {
     	List<DateScreenResponse> responses = screenService.getAllScreens();
     	return ResponseEntity.ok(responses);
     }
+    
+    // 상영될 모든 상영 정보 조회
+    @GetMapping("/screens/upcoming")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    public ResponseEntity<List<DateScreenResponse>> getUpcomingScreens() {
+    	List<DateScreenResponse> responses = screenService.getUpcomingScreens();
+    	return ResponseEntity.ok(responses);
+    }
 }

--- a/src/main/java/cinebox/controller/ScreenController.java
+++ b/src/main/java/cinebox/controller/ScreenController.java
@@ -1,15 +1,21 @@
 package cinebox.controller;
 
+import java.time.LocalDate;
+import java.util.List;
+
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import cinebox.dto.request.ScreenRequest;
@@ -19,13 +25,13 @@ import cinebox.service.ScreenService;
 import lombok.RequiredArgsConstructor;
 
 @RestController
-@RequestMapping("/api/screen")
+@RequestMapping("/api")
 @RequiredArgsConstructor
 public class ScreenController {
     private final ScreenService screenService;
 
     // 상영 정보 추가
-    @PostMapping
+    @PostMapping("/screens")
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     public ResponseEntity<ScreenResponse> createScreen(@RequestBody @Validated(CreateGroup.class) ScreenRequest request) {
         ScreenResponse responseDto = screenService.createScreen(request);
@@ -33,7 +39,7 @@ public class ScreenController {
     }
 
     // 상영 정보 수정
-    @PutMapping("/{screenId}")
+    @PutMapping("/screens/{screenId}")
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     public ResponseEntity<ScreenResponse> updateScreen(
             @PathVariable("screenId") Long screenId,
@@ -43,10 +49,26 @@ public class ScreenController {
     }
 
     // 상영 정보 삭제
-    @DeleteMapping("/{screenId}")
+    @DeleteMapping("/screens/{screenId}")
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     public ResponseEntity<Void> deleteScreen(@PathVariable("screenId") Long screenId) {
         screenService.deleteScreen(screenId);
 		return ResponseEntity.noContent().build();
+	}
+	
+	// 특정 영화 상영 날짜 목록 조회
+	@GetMapping("/movies/{movieId}/dates")
+	public ResponseEntity<List<LocalDate>> getAvailableDatesForMovie(@PathVariable("movieId") Long movieId) {
+		List<LocalDate> dates = screenService.getAvailableDatesForMovie(movieId);
+		return ResponseEntity.ok(dates);
+	}
+    
+    // 특정 영화의 날짜별 상영 정보 조회
+    @GetMapping("/movies/{movieId}/screens")
+    public ResponseEntity<List<ScreenResponse>> getScreensByDate(
+    		@PathVariable("movieId") Long movieId,
+    		@RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
+    	List<ScreenResponse> responses = screenService.getScreensByDate(movieId, date);
+		return ResponseEntity.ok(responses);
 	}
 }

--- a/src/main/java/cinebox/controller/ScreenController.java
+++ b/src/main/java/cinebox/controller/ScreenController.java
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import cinebox.dto.request.ScreenRequest;
+import cinebox.dto.response.AuditoriumScreenResponse;
 import cinebox.dto.response.ScreenResponse;
 import cinebox.dto.validation.CreateGroup;
 import cinebox.service.ScreenService;
@@ -65,10 +66,10 @@ public class ScreenController {
     
     // 특정 영화의 날짜별 상영 정보 조회
     @GetMapping("/movies/{movieId}/screens")
-    public ResponseEntity<List<ScreenResponse>> getScreensByDate(
+    public ResponseEntity<List<AuditoriumScreenResponse>> getScreensByDate(
     		@PathVariable("movieId") Long movieId,
     		@RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
-    	List<ScreenResponse> responses = screenService.getScreensByDate(movieId, date);
+    	List<AuditoriumScreenResponse> responses = screenService.getScreensByDate(movieId, date);
 		return ResponseEntity.ok(responses);
 	}
 }

--- a/src/main/java/cinebox/controller/ScreenController.java
+++ b/src/main/java/cinebox/controller/ScreenController.java
@@ -35,7 +35,8 @@ public class ScreenController {
     // 상영 정보 추가
     @PostMapping("/screens")
     @PreAuthorize("hasRole('ROLE_ADMIN')")
-    public ResponseEntity<ScreenResponse> createScreen(@RequestBody @Validated(CreateGroup.class) ScreenRequest request) {
+    public ResponseEntity<ScreenResponse> createScreen(
+    		@RequestBody @Validated(CreateGroup.class) ScreenRequest request) {
         ScreenResponse responseDto = screenService.createScreen(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
     }

--- a/src/main/java/cinebox/dto/request/ScreenRequest.java
+++ b/src/main/java/cinebox/dto/request/ScreenRequest.java
@@ -7,16 +7,16 @@ import cinebox.dto.validation.CreateGroup;
 import jakarta.validation.constraints.NotNull;
 
 public record ScreenRequest(
-		@NotNull(groups = CreateGroup.class)
+		@NotNull(groups = CreateGroup.class, message = "Movie Id를 입력해주세요.")
 		Long movieId,
 		
-		@NotNull(groups = CreateGroup.class)
+		@NotNull(groups = CreateGroup.class, message = "Auditorium Id를 입력해주세요.")
 		Long auditoriumId,
 		
-		@NotNull(groups = CreateGroup.class)
+		@NotNull(groups = CreateGroup.class, message = "영화 시작 시간을 입력해주세요.")
 		LocalDateTime startTime,
 		
-		@NotNull(groups = CreateGroup.class)
+		@NotNull(groups = CreateGroup.class, message = "예매 가격을 입력해주세요.")
 		BigDecimal price
 ) {
 	

--- a/src/main/java/cinebox/dto/request/ScreenRequest.java
+++ b/src/main/java/cinebox/dto/request/ScreenRequest.java
@@ -1,24 +1,23 @@
 package cinebox.dto.request;
 
-import lombok.Getter;
-
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
 import cinebox.dto.validation.CreateGroup;
 import jakarta.validation.constraints.NotNull;
 
-@Getter
-public class ScreenRequest {
-	@NotNull(groups = CreateGroup.class)
-	private Long movieId;
-
-	@NotNull(groups = CreateGroup.class)
-	private Long auditoriumId;
-
-	@NotNull(groups = CreateGroup.class)
-	private LocalDateTime startTime;
-
-	@NotNull(groups = CreateGroup.class)
-	private BigDecimal price;
+public record ScreenRequest(
+		@NotNull(groups = CreateGroup.class)
+		Long movieId,
+		
+		@NotNull(groups = CreateGroup.class)
+		Long auditoriumId,
+		
+		@NotNull(groups = CreateGroup.class)
+		LocalDateTime startTime,
+		
+		@NotNull(groups = CreateGroup.class)
+		BigDecimal price
+) {
+	
 }

--- a/src/main/java/cinebox/dto/response/AuditoriumScreenResponse.java
+++ b/src/main/java/cinebox/dto/response/AuditoriumScreenResponse.java
@@ -1,0 +1,22 @@
+package cinebox.dto.response;
+
+import java.util.List;
+
+public record AuditoriumScreenResponse(
+		Long auditoriumId,
+		String auditoriumName,
+		List<ScreenResponse> screens
+) {
+	public static AuditoriumScreenResponse from(List<ScreenResponse> screens) {
+		if (screens == null || screens.isEmpty()) {
+			throw new IllegalArgumentException("Empty Screen List");
+		}
+		
+		ScreenResponse response = screens.get(0);
+		return new AuditoriumScreenResponse(
+				response.auditoriumId(),
+				response.auditoriumName(),
+				screens
+		);
+	}
+}

--- a/src/main/java/cinebox/dto/response/DateScreenResponse.java
+++ b/src/main/java/cinebox/dto/response/DateScreenResponse.java
@@ -1,0 +1,22 @@
+package cinebox.dto.response;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public record DateScreenResponse(
+		LocalDate date,
+		List<AuditoriumScreenResponse> auditoriums
+) {
+	public static DateScreenResponse from(LocalDate date, List<ScreenResponse> screens) {
+		Map<Long, List<ScreenResponse>> groupedByAuditorium = screens.stream()
+				.collect(Collectors.groupingBy(ScreenResponse::auditoriumId));
+		
+		List<AuditoriumScreenResponse> auditoriumScreens = groupedByAuditorium.values().stream()
+				.map(AuditoriumScreenResponse::from)
+				.collect(Collectors.toList());
+		
+		return new DateScreenResponse(date, auditoriumScreens);
+	}
+}

--- a/src/main/java/cinebox/dto/response/ScreenResponse.java
+++ b/src/main/java/cinebox/dto/response/ScreenResponse.java
@@ -1,26 +1,39 @@
 package cinebox.dto.response;
 
-import cinebox.entity.Screen;
-import lombok.Getter;
-
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
-@Getter
-public class ScreenResponse {
-    private Long screenId;
-    private Long movieId;
-    private Long auditoriumId;
-    private LocalDateTime startTime;
-    private LocalDateTime endTime;
-    private BigDecimal price;
+import cinebox.entity.Auditorium;
+import cinebox.entity.Screen;
 
-    public ScreenResponse(Screen screen) {
-        this.screenId = screen.getScreenId();
-        this.movieId = screen.getMovie().getMovieId();
-        this.auditoriumId = screen.getAuditorium().getAuditoriumId();
-        this.startTime = screen.getStartTime();
-        this.endTime = screen.getEndTime();
-        this.price = screen.getPrice();
-    }
+public record ScreenResponse(
+		Long screenId,
+		Long movieId,
+		Long auditoriumId,
+		String auditoriumName,
+		Integer auditoriumCapacity,
+		Integer auditoriumRemain,
+		LocalDateTime startTime,
+		LocalDateTime endTime,
+		BigDecimal price
+) {
+	public static ScreenResponse from(Screen screen) {
+		Auditorium auditorium = screen.getAuditorium();
+		
+		int capacity = auditorium.getCapacity();
+		int booked = screen.getBookingSeats() != null ? screen.getBookingSeats().size() : 0;
+		int remain = capacity - booked; 
+		
+		return new ScreenResponse(
+				screen.getScreenId(),
+				screen.getMovie().getMovieId(),
+				auditorium.getAuditoriumId(),
+				auditorium.getName(),
+				capacity,
+				remain,
+				screen.getStartTime(),
+				screen.getEndTime(),
+				screen.getPrice()
+		);
+	}
 }

--- a/src/main/java/cinebox/repository/ScreenRepository.java
+++ b/src/main/java/cinebox/repository/ScreenRepository.java
@@ -20,4 +20,6 @@ public interface ScreenRepository extends JpaRepository<Screen, Long> {
 
 	// 특정 날짜 하루동안의 상영 정보 조회
 	List<Screen> findByMovie_MovieIdAndStartTimeBetween(Long movieId, LocalDateTime startOfDay, LocalDateTime endOfDay);
+
+	List<Screen> findByMovie_MovieIdAndStartTimeBetweenOrderByStartTimeAsc(Long movieId, LocalDateTime startOfDay, LocalDateTime endOfDay);
 }

--- a/src/main/java/cinebox/repository/ScreenRepository.java
+++ b/src/main/java/cinebox/repository/ScreenRepository.java
@@ -22,4 +22,6 @@ public interface ScreenRepository extends JpaRepository<Screen, Long> {
 	List<Screen> findByMovie_MovieIdAndStartTimeBetween(Long movieId, LocalDateTime startOfDay, LocalDateTime endOfDay);
 
 	List<Screen> findByMovie_MovieIdAndStartTimeBetweenOrderByStartTimeAsc(Long movieId, LocalDateTime startOfDay, LocalDateTime endOfDay);
+
+	List<Screen> findByStartTimeAfter(LocalDateTime datetime);
 }

--- a/src/main/java/cinebox/service/MovieService.java
+++ b/src/main/java/cinebox/service/MovieService.java
@@ -1,11 +1,9 @@
 package cinebox.service;
 
-import java.time.LocalDate;
 import java.util.List;
 
 import cinebox.dto.request.MovieRequest;
 import cinebox.dto.response.MovieResponse;
-import cinebox.dto.response.ScreenResponse;
 
 public interface MovieService {
 	// create
@@ -18,12 +16,6 @@ public interface MovieService {
 	
 	// 특정 영화 조회
 	MovieResponse getMovie(Long movieId);
-
-	// 특정 영화 상영 날짜 목록 조회
-	List<LocalDate> getAvailableDatesForMovie(Long movieId);
-	
-    // 특정 영화의 날짜별 상영 정보 조회
-	List<ScreenResponse> getScreensByDate(Long movieId, LocalDate date);
 	
 	// update
 	// 영화 정보 수정

--- a/src/main/java/cinebox/service/MovieServiceImpl.java
+++ b/src/main/java/cinebox/service/MovieServiceImpl.java
@@ -7,6 +7,7 @@ import java.util.stream.Collectors;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import cinebox.common.enums.MovieStatus;
 import cinebox.common.exception.movie.DuplicatedMovieException;
@@ -25,6 +26,7 @@ public class MovieServiceImpl implements MovieService {
 	
 	// 영화 등록(생성)
 	@Override
+	@Transactional
 	public MovieResponse registerMovie(MovieRequest request) {
 		if (movieRepository.existsByTitleAndReleaseDate(request.title(), request.releaseDate())) {
 			throw DuplicatedMovieException.EXCEPTION;
@@ -37,6 +39,7 @@ public class MovieServiceImpl implements MovieService {
 
 	// 영화 목록 조회 (정렬, 검색)
 	@Override
+	@Transactional(readOnly = true)
 	public List<MovieResponse> getAllMovies(String sortBy, String searchText) {
 		List<Movie> movies;
 		
@@ -63,6 +66,7 @@ public class MovieServiceImpl implements MovieService {
 
 	// 특정 영화 조회
 	@Override
+	@Transactional(readOnly = true)
 	public MovieResponse getMovie(Long movieId) {
 		Movie movie = movieRepository.findById(movieId)
 				.orElseThrow(() -> NotFoundMovieException.EXCEPTION);
@@ -76,6 +80,7 @@ public class MovieServiceImpl implements MovieService {
 	
 	// 영화 정보 수정
 	@Override
+	@Transactional
 	public MovieResponse updateMovie(Long movieId, MovieRequest request) {
 		Movie movie = movieRepository.findById(movieId)
 				.orElseThrow(() -> NotFoundMovieException.EXCEPTION);
@@ -88,6 +93,7 @@ public class MovieServiceImpl implements MovieService {
 
 	// 영화 삭제
 	@Override
+	@Transactional
 	public void deleteMovie(Long movieId) {
 		Movie movie = movieRepository.findById(movieId)
 				.orElseThrow(() -> NotFoundMovieException.EXCEPTION);

--- a/src/main/java/cinebox/service/MovieServiceImpl.java
+++ b/src/main/java/cinebox/service/MovieServiceImpl.java
@@ -1,16 +1,12 @@
 package cinebox.service;
 
-import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import cinebox.common.enums.MovieStatus;
 import cinebox.common.exception.movie.DuplicatedMovieException;
@@ -18,18 +14,14 @@ import cinebox.common.exception.movie.MovieDeleteFailedException;
 import cinebox.common.exception.movie.NotFoundMovieException;
 import cinebox.dto.request.MovieRequest;
 import cinebox.dto.response.MovieResponse;
-import cinebox.dto.response.ScreenResponse;
 import cinebox.entity.Movie;
-import cinebox.entity.Screen;
 import cinebox.repository.MovieRepository;
-import cinebox.repository.ScreenRepository;
 import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
 public class MovieServiceImpl implements MovieService {
 	private final MovieRepository movieRepository;
-	private final ScreenRepository screenRepository;
 	
 	// 영화 등록(생성)
 	@Override
@@ -80,36 +72,6 @@ public class MovieServiceImpl implements MovieService {
 			throw NotFoundMovieException.EXCEPTION;
 		}
 		return MovieResponse.from(movie);
-	}
-	
-	// 특정 영화 상영 날짜 목록 조회
-	@Override
-	public List<LocalDate> getAvailableDatesForMovie(Long movieId) {
-		Movie movie = movieRepository.findById(movieId)
-				.orElseThrow(() -> NotFoundMovieException.EXCEPTION);
-		
-		List<Screen> screens = movie.getScreens();
-		
-		Set<LocalDate> dateSet = screens.stream()
-				.map(screen -> screen.getStartTime().toLocalDate())
-				.collect(Collectors.toSet());
-		
-		return dateSet.stream().sorted().collect(Collectors.toList());
-	}
-
-	// 날짜별 상영 정보 조회
-	@Override
-	@Transactional(readOnly = true)
-	public List<ScreenResponse> getScreensByDate(Long movieId, LocalDate date) {
-		movieRepository.findById(movieId).orElseThrow(() -> NotFoundMovieException.EXCEPTION);
-		
-		LocalDateTime startOfDay = date.atStartOfDay();
-		LocalDateTime endOfDay = date.plusDays(1).atStartOfDay();
-		
-		List<Screen> screens = screenRepository.findByMovie_MovieIdAndStartTimeBetweenOrderByStartTimeAsc(movieId, startOfDay, endOfDay);
-		return screens.stream()
-				.map(ScreenResponse::from)
-				.collect(Collectors.toList());
 	}
 	
 	// 영화 정보 수정

--- a/src/main/java/cinebox/service/MovieServiceImpl.java
+++ b/src/main/java/cinebox/service/MovieServiceImpl.java
@@ -108,7 +108,7 @@ public class MovieServiceImpl implements MovieService {
 		
 		List<Screen> screens = screenRepository.findByMovie_MovieIdAndStartTimeBetween(movieId, startOfDay, endOfDay);
 		return screens.stream()
-				.map(ScreenResponse::new)
+				.map(ScreenResponse::from)
 				.collect(Collectors.toList());
 	}
 	

--- a/src/main/java/cinebox/service/MovieServiceImpl.java
+++ b/src/main/java/cinebox/service/MovieServiceImpl.java
@@ -106,7 +106,7 @@ public class MovieServiceImpl implements MovieService {
 		LocalDateTime startOfDay = date.atStartOfDay();
 		LocalDateTime endOfDay = date.plusDays(1).atStartOfDay();
 		
-		List<Screen> screens = screenRepository.findByMovie_MovieIdAndStartTimeBetween(movieId, startOfDay, endOfDay);
+		List<Screen> screens = screenRepository.findByMovie_MovieIdAndStartTimeBetweenOrderByStartTimeAsc(movieId, startOfDay, endOfDay);
 		return screens.stream()
 				.map(ScreenResponse::from)
 				.collect(Collectors.toList());

--- a/src/main/java/cinebox/service/ScreenService.java
+++ b/src/main/java/cinebox/service/ScreenService.java
@@ -30,16 +30,16 @@ public class ScreenService {
 	// 상영 정보 추가
 	@Transactional
 	public ScreenResponse createScreen(ScreenRequest request) {
-		Movie movie = movieRepository.findById(request.getMovieId())
+		Movie movie = movieRepository.findById(request.movieId())
 				.orElseThrow(() -> NotFoundMovieException.EXCEPTION);
 
-		Auditorium auditorium = auditoriumRepository.findById(request.getAuditoriumId())
+		Auditorium auditorium = auditoriumRepository.findById(request.auditoriumId())
 				.orElseThrow(() -> NotFoundAuditoriumException.EXCEPTION);
 
-		LocalDateTime endTime = request.getStartTime().plusMinutes(movie.getRunTime() + 10); // 🎯 endTime 자동 계산
+		LocalDateTime endTime = request.startTime().plusMinutes(movie.getRunTime() + 10); // 🎯 endTime 자동 계산
 		
 		List<Screen> overlappingScreens = screenRepository
-				.findByAuditoriumAndStartTimeLessThanAndEndTimeGreaterThan(auditorium, endTime, request.getStartTime());
+				.findByAuditoriumAndStartTimeLessThanAndEndTimeGreaterThan(auditorium, endTime, request.startTime());
 		if(!overlappingScreens.isEmpty()) {
 			throw ScreenTimeConflictException.EXCEPTION;
 		}
@@ -47,13 +47,13 @@ public class ScreenService {
 		Screen screen = Screen.builder()
 				.movie(movie)
 				.auditorium(auditorium)
-				.startTime(request.getStartTime())
+				.startTime(request.startTime())
 				.endTime(endTime)
-				.price(request.getPrice())
+				.price(request.price())
 				.build();
 
 		screenRepository.save(screen);
-		return new ScreenResponse(screen);
+		return ScreenResponse.from(screen);
 	}
 
 	// 상영 정보 수정
@@ -61,17 +61,17 @@ public class ScreenService {
 	public ScreenResponse updateScreen(Long screenId, ScreenRequest request) {
 		Screen screen = screenRepository.findById(screenId).orElseThrow(() -> NotFoundScreenException.EXCEPTION);
 
-		Movie movie = request.getMovieId() != null
-				? movieRepository.findById(request.getMovieId())
+		Movie movie = request.movieId() != null
+				? movieRepository.findById(request.movieId())
 						.orElseThrow(() -> NotFoundMovieException.EXCEPTION)
 				: screen.getMovie();
 		
-		Auditorium auditorium = request.getAuditoriumId() != null 
-	            ? auditoriumRepository.findById(request.getAuditoriumId())
+		Auditorium auditorium = request.auditoriumId() != null 
+	            ? auditoriumRepository.findById(request.auditoriumId())
 						.orElseThrow(() -> NotFoundAuditoriumException.EXCEPTION)
 				: screen.getAuditorium();
 		
-		LocalDateTime startTime = request.getStartTime() != null ? request.getStartTime() : screen.getStartTime();
+		LocalDateTime startTime = request.startTime() != null ? request.startTime() : screen.getStartTime();
 		LocalDateTime endTime = startTime.plusMinutes(movie.getRunTime() + 10);
 		
 		List<Screen> overlappingScreens = screenRepository
@@ -80,8 +80,8 @@ public class ScreenService {
             throw ScreenTimeConflictException.EXCEPTION;
         }
 
-		screen.updateScreen(movie, auditorium, startTime, request.getPrice());
-		return new ScreenResponse(screenRepository.save(screen));
+		screen.updateScreen(movie, auditorium, startTime, request.price());
+		return ScreenResponse.from(screenRepository.save(screen));
 	}
 
 	// 상영 정보 삭제

--- a/src/main/java/cinebox/service/ScreenService.java
+++ b/src/main/java/cinebox/service/ScreenService.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import java.util.List;
 
 import cinebox.dto.request.ScreenRequest;
+import cinebox.dto.response.AuditoriumScreenResponse;
 import cinebox.dto.response.ScreenResponse;
 
 public interface ScreenService {
@@ -20,5 +21,5 @@ public interface ScreenService {
 	List<LocalDate> getAvailableDatesForMovie(Long movieId);
 	
     // 특정 영화의 날짜별 상영 정보 조회
-	List<ScreenResponse> getScreensByDate(Long movieId, LocalDate date);
+	List<AuditoriumScreenResponse> getScreensByDate(Long movieId, LocalDate date);
 }

--- a/src/main/java/cinebox/service/ScreenService.java
+++ b/src/main/java/cinebox/service/ScreenService.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import cinebox.dto.request.ScreenRequest;
 import cinebox.dto.response.AuditoriumScreenResponse;
+import cinebox.dto.response.DateScreenResponse;
 import cinebox.dto.response.ScreenResponse;
 
 public interface ScreenService {
@@ -22,4 +23,7 @@ public interface ScreenService {
 	
     // 특정 영화의 날짜별 상영 정보 조회
 	List<AuditoriumScreenResponse> getScreensByDate(Long movieId, LocalDate date);
+
+	// 모든 상영 정보 조회
+	List<DateScreenResponse> getAllScreens();
 }

--- a/src/main/java/cinebox/service/ScreenService.java
+++ b/src/main/java/cinebox/service/ScreenService.java
@@ -1,5 +1,8 @@
 package cinebox.service;
 
+import java.time.LocalDate;
+import java.util.List;
+
 import cinebox.dto.request.ScreenRequest;
 import cinebox.dto.response.ScreenResponse;
 
@@ -12,4 +15,10 @@ public interface ScreenService {
 
 	// 상영 정보 삭제
 	void deleteScreen(Long screenId);
+
+	// 특정 영화 상영 날짜 목록 조회
+	List<LocalDate> getAvailableDatesForMovie(Long movieId);
+	
+    // 특정 영화의 날짜별 상영 정보 조회
+	List<ScreenResponse> getScreensByDate(Long movieId, LocalDate date);
 }

--- a/src/main/java/cinebox/service/ScreenService.java
+++ b/src/main/java/cinebox/service/ScreenService.java
@@ -1,93 +1,15 @@
 package cinebox.service;
 
-import java.time.LocalDateTime;
-import java.util.List;
-
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
-import cinebox.common.exception.auditorium.NotFoundAuditoriumException;
-import cinebox.common.exception.movie.NotFoundMovieException;
-import cinebox.common.exception.screen.NotFoundScreenException;
-import cinebox.common.exception.screen.ScreenTimeConflictException;
 import cinebox.dto.request.ScreenRequest;
 import cinebox.dto.response.ScreenResponse;
-import cinebox.entity.Auditorium;
-import cinebox.entity.Movie;
-import cinebox.entity.Screen;
-import cinebox.repository.AuditoriumRepository;
-import cinebox.repository.MovieRepository;
-import cinebox.repository.ScreenRepository;
-import lombok.RequiredArgsConstructor;
 
-@Service
-@RequiredArgsConstructor
-public class ScreenService {
-	private final ScreenRepository screenRepository;
-	private final MovieRepository movieRepository;
-	private final AuditoriumRepository auditoriumRepository;
-
+public interface ScreenService {
 	// 상영 정보 추가
-	@Transactional
-	public ScreenResponse createScreen(ScreenRequest request) {
-		Movie movie = movieRepository.findById(request.movieId())
-				.orElseThrow(() -> NotFoundMovieException.EXCEPTION);
-
-		Auditorium auditorium = auditoriumRepository.findById(request.auditoriumId())
-				.orElseThrow(() -> NotFoundAuditoriumException.EXCEPTION);
-
-		LocalDateTime endTime = request.startTime().plusMinutes(movie.getRunTime() + 10); // 🎯 endTime 자동 계산
-		
-		List<Screen> overlappingScreens = screenRepository
-				.findByAuditoriumAndStartTimeLessThanAndEndTimeGreaterThan(auditorium, endTime, request.startTime());
-		if(!overlappingScreens.isEmpty()) {
-			throw ScreenTimeConflictException.EXCEPTION;
-		}
-
-		Screen screen = Screen.builder()
-				.movie(movie)
-				.auditorium(auditorium)
-				.startTime(request.startTime())
-				.endTime(endTime)
-				.price(request.price())
-				.build();
-
-		screenRepository.save(screen);
-		return ScreenResponse.from(screen);
-	}
+	ScreenResponse createScreen(ScreenRequest request);
 
 	// 상영 정보 수정
-	@Transactional
-	public ScreenResponse updateScreen(Long screenId, ScreenRequest request) {
-		Screen screen = screenRepository.findById(screenId).orElseThrow(() -> NotFoundScreenException.EXCEPTION);
-
-		Movie movie = request.movieId() != null
-				? movieRepository.findById(request.movieId())
-						.orElseThrow(() -> NotFoundMovieException.EXCEPTION)
-				: screen.getMovie();
-		
-		Auditorium auditorium = request.auditoriumId() != null 
-	            ? auditoriumRepository.findById(request.auditoriumId())
-						.orElseThrow(() -> NotFoundAuditoriumException.EXCEPTION)
-				: screen.getAuditorium();
-		
-		LocalDateTime startTime = request.startTime() != null ? request.startTime() : screen.getStartTime();
-		LocalDateTime endTime = startTime.plusMinutes(movie.getRunTime() + 10);
-		
-		List<Screen> overlappingScreens = screenRepository
-				.findByAuditoriumAndScreenIdNotAndStartTimeLessThanAndEndTimeGreaterThan(auditorium, screenId, endTime, startTime);
-        if (!overlappingScreens.isEmpty()) {
-            throw ScreenTimeConflictException.EXCEPTION;
-        }
-
-		screen.updateScreen(movie, auditorium, startTime, request.price());
-		return ScreenResponse.from(screenRepository.save(screen));
-	}
+	ScreenResponse updateScreen(Long screenId, ScreenRequest request);
 
 	// 상영 정보 삭제
-	@Transactional
-	public void deleteScreen(Long screenId) {
-		Screen screen = screenRepository.findById(screenId).orElseThrow(() -> NotFoundScreenException.EXCEPTION);
-		screenRepository.delete(screen);
-	}
+	void deleteScreen(Long screenId);
 }

--- a/src/main/java/cinebox/service/ScreenService.java
+++ b/src/main/java/cinebox/service/ScreenService.java
@@ -20,10 +20,13 @@ public interface ScreenService {
 
 	// 특정 영화 상영 날짜 목록 조회
 	List<LocalDate> getAvailableDatesForMovie(Long movieId);
-	
-    // 특정 영화의 날짜별 상영 정보 조회
+
+	// 특정 영화의 날짜별 상영 정보 조회
 	List<AuditoriumScreenResponse> getScreensByDate(Long movieId, LocalDate date);
 
 	// 모든 상영 정보 조회
 	List<DateScreenResponse> getAllScreens();
+
+	// 상영될 모든 상영 정보 조회
+	List<DateScreenResponse> getUpcomingScreens();
 }

--- a/src/main/java/cinebox/service/ScreenServiceImpl.java
+++ b/src/main/java/cinebox/service/ScreenServiceImpl.java
@@ -1,0 +1,96 @@
+package cinebox.service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import cinebox.common.exception.auditorium.NotFoundAuditoriumException;
+import cinebox.common.exception.movie.NotFoundMovieException;
+import cinebox.common.exception.screen.NotFoundScreenException;
+import cinebox.common.exception.screen.ScreenTimeConflictException;
+import cinebox.dto.request.ScreenRequest;
+import cinebox.dto.response.ScreenResponse;
+import cinebox.entity.Auditorium;
+import cinebox.entity.Movie;
+import cinebox.entity.Screen;
+import cinebox.repository.AuditoriumRepository;
+import cinebox.repository.MovieRepository;
+import cinebox.repository.ScreenRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ScreenServiceImpl implements ScreenService {
+	private final ScreenRepository screenRepository;
+	private final MovieRepository movieRepository;
+	private final AuditoriumRepository auditoriumRepository;
+
+	// 상영 정보 추가
+	@Override
+	@Transactional
+	public ScreenResponse createScreen(ScreenRequest request) {
+		Movie movie = movieRepository.findById(request.movieId())
+				.orElseThrow(() -> NotFoundMovieException.EXCEPTION);
+
+		Auditorium auditorium = auditoriumRepository.findById(request.auditoriumId())
+				.orElseThrow(() -> NotFoundAuditoriumException.EXCEPTION);
+
+		LocalDateTime endTime = request.startTime().plusMinutes(movie.getRunTime() + 10); // 🎯 endTime 자동 계산
+		
+		List<Screen> overlappingScreens = screenRepository
+				.findByAuditoriumAndStartTimeLessThanAndEndTimeGreaterThan(auditorium, endTime, request.startTime());
+		if(!overlappingScreens.isEmpty()) {
+			throw ScreenTimeConflictException.EXCEPTION;
+		}
+
+		Screen screen = Screen.builder()
+				.movie(movie)
+				.auditorium(auditorium)
+				.startTime(request.startTime())
+				.endTime(endTime)
+				.price(request.price())
+				.build();
+
+		screenRepository.save(screen);
+		return ScreenResponse.from(screen);
+	}
+
+	// 상영 정보 수정
+	@Override
+	@Transactional
+	public ScreenResponse updateScreen(Long screenId, ScreenRequest request) {
+		Screen screen = screenRepository.findById(screenId).orElseThrow(() -> NotFoundScreenException.EXCEPTION);
+
+		Movie movie = request.movieId() != null
+				? movieRepository.findById(request.movieId())
+						.orElseThrow(() -> NotFoundMovieException.EXCEPTION)
+				: screen.getMovie();
+		
+		Auditorium auditorium = request.auditoriumId() != null 
+	            ? auditoriumRepository.findById(request.auditoriumId())
+						.orElseThrow(() -> NotFoundAuditoriumException.EXCEPTION)
+				: screen.getAuditorium();
+		
+		LocalDateTime startTime = request.startTime() != null ? request.startTime() : screen.getStartTime();
+		LocalDateTime endTime = startTime.plusMinutes(movie.getRunTime() + 10);
+		
+		List<Screen> overlappingScreens = screenRepository
+				.findByAuditoriumAndScreenIdNotAndStartTimeLessThanAndEndTimeGreaterThan(auditorium, screenId, endTime, startTime);
+        if (!overlappingScreens.isEmpty()) {
+            throw ScreenTimeConflictException.EXCEPTION;
+        }
+
+		screen.updateScreen(movie, auditorium, startTime, request.price());
+		return ScreenResponse.from(screenRepository.save(screen));
+	}
+
+	// 상영 정보 삭제
+	@Override
+	@Transactional
+	public void deleteScreen(Long screenId) {
+		Screen screen = screenRepository.findById(screenId).orElseThrow(() -> NotFoundScreenException.EXCEPTION);
+		screenRepository.delete(screen);
+	}
+}

--- a/src/main/java/cinebox/service/ScreenServiceImpl.java
+++ b/src/main/java/cinebox/service/ScreenServiceImpl.java
@@ -5,6 +5,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
@@ -144,6 +145,7 @@ public class ScreenServiceImpl implements ScreenService {
 				.collect(Collectors.toList());
 	}
 
+	// 모든 상영 정보 조회 (날짜 내림차순)
 	@Override
 	@Transactional(readOnly = true)
 	public List<DateScreenResponse> getAllScreens() {
@@ -155,6 +157,25 @@ public class ScreenServiceImpl implements ScreenService {
 		
 		Map<LocalDate, List<ScreenResponse>> grouped = screenResponses.stream()
 				.collect(Collectors.groupingBy(response -> response.startTime().toLocalDate()));
+		
+		return grouped.entrySet().stream()
+				.map(entry -> DateScreenResponse.from(entry.getKey(), entry.getValue()))
+				.collect(Collectors.toList());
+	}
+
+	// 상영될 모든 상영 정보 조회 (날짜 오름차순)
+	@Override
+	@Transactional(readOnly = true)
+	public List<DateScreenResponse> getUpcomingScreens() {
+		LocalDateTime now = LocalDateTime.now();
+		List<Screen> screens = screenRepository.findByStartTimeAfter(now);
+		
+		List<ScreenResponse> screenResponses = screens.stream()
+				.map(ScreenResponse::from)
+				.collect(Collectors.toList());
+		
+		Map<LocalDate, List<ScreenResponse>> grouped = new TreeMap<>(screenResponses.stream()
+				.collect(Collectors.groupingBy(response -> response.startTime().toLocalDate())));
 		
 		return grouped.entrySet().stream()
 				.map(entry -> DateScreenResponse.from(entry.getKey(), entry.getValue()))

--- a/src/main/java/cinebox/service/ScreenServiceImpl.java
+++ b/src/main/java/cinebox/service/ScreenServiceImpl.java
@@ -16,6 +16,7 @@ import cinebox.common.exception.screen.NotFoundScreenException;
 import cinebox.common.exception.screen.ScreenTimeConflictException;
 import cinebox.dto.request.ScreenRequest;
 import cinebox.dto.response.AuditoriumScreenResponse;
+import cinebox.dto.response.DateScreenResponse;
 import cinebox.dto.response.ScreenResponse;
 import cinebox.entity.Auditorium;
 import cinebox.entity.Movie;
@@ -131,7 +132,7 @@ public class ScreenServiceImpl implements ScreenService {
 		List<Screen> screens = screenRepository
 				.findByMovie_MovieIdAndStartTimeBetweenOrderByStartTimeAsc(movieId, startOfDay, endOfDay);
 
-		List<ScreenResponse> screenResponses =  screens.stream()
+		List<ScreenResponse> screenResponses = screens.stream()
 				.map(ScreenResponse::from)
 				.collect(Collectors.toList());
 		
@@ -140,6 +141,23 @@ public class ScreenServiceImpl implements ScreenService {
 		
 		return grouped.values().stream()
 				.map(AuditoriumScreenResponse::from)
+				.collect(Collectors.toList());
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public List<DateScreenResponse> getAllScreens() {
+		List<Screen> screens = screenRepository.findAll();
+		
+		List<ScreenResponse> screenResponses = screens.stream()
+				.map(ScreenResponse::from)
+				.collect(Collectors.toList());
+		
+		Map<LocalDate, List<ScreenResponse>> grouped = screenResponses.stream()
+				.collect(Collectors.groupingBy(response -> response.startTime().toLocalDate()));
+		
+		return grouped.entrySet().stream()
+				.map(entry -> DateScreenResponse.from(entry.getKey(), entry.getValue()))
 				.collect(Collectors.toList());
 	}
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

#67 

## 📝작업 내용

- Request, Response 레코드로 리팩토링
- Response에 잔여석, 총 좌석, 상영관명 추가
- 상영 정보 조회 시, 상영관 별로 그룹화하여 응답
- 모든 상영 정보 조회에 대한 api 구현
   - 날짜 내림차순
- 아직 상영되지 않은 모든 상영 정보 조회에 대한 api 구현
   - 날짜 오름차순

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
