### PR TITLE
Feat(#55): Redis, Cookie를 통한 JWT 토큰 관리 구현

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,18 @@
 			<version>4.4.0</version>
 		</dependency>
 		
+	    <!-- Spring Boot Starter for Data Redis -->
+	    <dependency>
+	        <groupId>org.springframework.boot</groupId>
+	        <artifactId>spring-boot-starter-data-redis</artifactId>
+	    </dependency>
+	    
+	    <!-- Spring Session for Redis -->
+	    <dependency>
+	        <groupId>org.springframework.session</groupId>
+	        <artifactId>spring-session-data-redis</artifactId>
+	    </dependency>
+
 	</dependencies>
 
 	<build>

--- a/src/main/java/cinebox/common/exception/ExceptionMessage.java
+++ b/src/main/java/cinebox/common/exception/ExceptionMessage.java
@@ -8,6 +8,9 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum ExceptionMessage {
+	// auth
+	NOT_FOUND_TOKEN("다시 로그인 해 주세요.", HttpStatus.NOT_FOUND, "Not Found Token"),
+	
 	// user
 	NOT_FOUND_USER("유효하지 않은 UserId 입니다.", HttpStatus.NOT_FOUND, "Not Found UserId"),
 	ALREADY_EXIST_USER("사용 중인 아이디 입니다.", HttpStatus.BAD_REQUEST, "Already Exist UserId"),

--- a/src/main/java/cinebox/common/exception/auth/NotFoundTokenException.java
+++ b/src/main/java/cinebox/common/exception/auth/NotFoundTokenException.java
@@ -1,0 +1,14 @@
+package cinebox.common.exception.auth;
+
+import cinebox.common.exception.BaseException;
+import cinebox.common.exception.ExceptionMessage;
+import cinebox.common.exception.booking.NotFoundBookingException;
+
+public class NotFoundTokenException extends BaseException {
+	public static final BaseException EXCEPTION = new NotFoundTokenException();
+	
+	private NotFoundTokenException() {
+		super(ExceptionMessage.NOT_FOUND_TOKEN);
+	
+	}
+}

--- a/src/main/java/cinebox/controller/AuthController.java
+++ b/src/main/java/cinebox/controller/AuthController.java
@@ -11,7 +11,7 @@ import cinebox.dto.request.AuthRequest;
 import cinebox.dto.request.UserRequest;
 import cinebox.dto.response.AuthResponse;
 import cinebox.dto.response.UserResponse;
-import cinebox.service.UserService;
+import cinebox.service.AuthService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -20,11 +20,11 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor
 public class AuthController {
-	private final UserService userService;
+	private final AuthService authService;
 	
 	@PostMapping("/signup")
 	public ResponseEntity<UserResponse> signup(@RequestBody UserRequest user) {
-		UserResponse newUser = userService.signup(user);
+		UserResponse newUser = authService.signup(user);
 		return ResponseEntity.ok().body(newUser);
 	}
 	
@@ -32,7 +32,7 @@ public class AuthController {
 	public ResponseEntity<AuthResponse> login(
 			@RequestBody AuthRequest authRequest,
 			HttpServletResponse response) {
-		AuthResponse authResponse = userService.login(authRequest, response);
+		AuthResponse authResponse = authService.login(authRequest, response);
 		return ResponseEntity.ok(authResponse);	
 	}
 	

--- a/src/main/java/cinebox/controller/AuthController.java
+++ b/src/main/java/cinebox/controller/AuthController.java
@@ -13,6 +13,7 @@ import cinebox.dto.response.AuthResponse;
 import cinebox.dto.response.UserResponse;
 import cinebox.service.UserService;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -28,9 +29,11 @@ public class AuthController {
 	}
 	
 	@PostMapping("/login")
-	public ResponseEntity<AuthResponse> login(@RequestBody AuthRequest authRequest) {
-		AuthResponse response = userService.login(authRequest);
-		return ResponseEntity.ok(response);	
+	public ResponseEntity<AuthResponse> login(
+			@RequestBody AuthRequest authRequest,
+			HttpServletResponse response) {
+		AuthResponse authResponse = userService.login(authRequest, response);
+		return ResponseEntity.ok(authResponse);	
 	}
 	
 	@GetMapping("/logout")

--- a/src/main/java/cinebox/controller/ReviewController.java
+++ b/src/main/java/cinebox/controller/ReviewController.java
@@ -36,7 +36,7 @@ public class ReviewController {
 	}
 	
 	// 리뷰 수정
-	@PutMapping("/reivews/{reviewId}")
+	@PutMapping("/reviews/{reviewId}")
 	public ResponseEntity<ReviewResponse> updateReview(
 			@PathVariable("reviewId") Long reviewId,
 			@Validated(UpdateGroup.class) @RequestBody ReviewRequest request) {

--- a/src/main/java/cinebox/dto/response/AuthResponse.java
+++ b/src/main/java/cinebox/dto/response/AuthResponse.java
@@ -13,6 +13,9 @@ public class AuthResponse {
 //    private String role;
 //    private String token;
 	
+	private Long userId;
+	private String role;
+	private String identifier;
 	private String accessToken;
 	private String refreshToken;
 }

--- a/src/main/java/cinebox/dto/response/AuthResponse.java
+++ b/src/main/java/cinebox/dto/response/AuthResponse.java
@@ -8,14 +8,7 @@ import lombok.Setter;
 @Setter
 @AllArgsConstructor
 public class AuthResponse {
-//	private Long userId;
-//    private String identifier;
-//    private String role;
-//    private String token;
-	
 	private Long userId;
 	private String role;
 	private String identifier;
-	private String accessToken;
-	private String refreshToken;
 }

--- a/src/main/java/cinebox/dto/response/AuthResponse.java
+++ b/src/main/java/cinebox/dto/response/AuthResponse.java
@@ -8,8 +8,11 @@ import lombok.Setter;
 @Setter
 @AllArgsConstructor
 public class AuthResponse {
-	private Long userId;
-    private String identifier;
-    private String role;
-    private String token;
+//	private Long userId;
+//    private String identifier;
+//    private String role;
+//    private String token;
+	
+	private String accessToken;
+	private String refreshToken;
 }

--- a/src/main/java/cinebox/entity/Movie.java
+++ b/src/main/java/cinebox/entity/Movie.java
@@ -85,6 +85,7 @@ public class Movie extends BaseTimeEntity {
 				.runTime(request.runtime())
 				.ratingGrade(request.ratingGrade())
 				.status(request.status() != null ? request.status() : MovieStatus.UNRELEASED)
+				.likeCount(0)
 				.build();
 	}
 	

--- a/src/main/java/cinebox/entity/TokenRedis.java
+++ b/src/main/java/cinebox/entity/TokenRedis.java
@@ -6,19 +6,21 @@ import org.springframework.data.redis.core.index.Indexed;
 import jakarta.persistence.Id;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor
+@NoArgsConstructor
 @RedisHash(value = "token", timeToLive = 60 * 60 * 24 * 7)
 public class TokenRedis {
 	@Id
 	private String id;
-	
+
 	@Indexed
 	private String accessToken;
-	
+
 	private String refreshToken;
-	
+
 	public void updateAccessToken(String newAccessToken) {
 		this.accessToken = newAccessToken;
 	}

--- a/src/main/java/cinebox/entity/TokenRedis.java
+++ b/src/main/java/cinebox/entity/TokenRedis.java
@@ -1,0 +1,25 @@
+package cinebox.entity;
+
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.index.Indexed;
+
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@RedisHash(value = "token", timeToLive = 60 * 60 * 24 * 7)
+public class TokenRedis {
+	@Id
+	private String id;
+	
+	@Indexed
+	private String accessToken;
+	
+	private String refreshToken;
+	
+	public void updateAccessToken(String newAccessToken) {
+		this.accessToken = newAccessToken;
+	}
+}

--- a/src/main/java/cinebox/repository/TokenRedisRepository.java
+++ b/src/main/java/cinebox/repository/TokenRedisRepository.java
@@ -1,0 +1,11 @@
+package cinebox.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.repository.CrudRepository;
+
+import cinebox.entity.TokenRedis;
+
+public interface TokenRedisRepository extends CrudRepository<TokenRedis, String> {
+	Optional<TokenRedis> findByAccessToken(String accessToken);
+}

--- a/src/main/java/cinebox/security/JwtAuthenticationFilter.java
+++ b/src/main/java/cinebox/security/JwtAuthenticationFilter.java
@@ -1,50 +1,84 @@
 package cinebox.security;
 
-import com.auth0.jwt.exceptions.JWTVerificationException;
-import jakarta.servlet.FilterChain;
-import jakarta.servlet.ServletException;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
-import lombok.RequiredArgsConstructor;
+import java.io.IOException;
+import java.util.Optional;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
 
-import java.io.IOException;
+import com.auth0.jwt.exceptions.JWTVerificationException;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 	private final JwtTokenProvider jwtTokenProvider;
 
-	@Override
-	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
-			throws ServletException, IOException {
-
-		String token = resolveToken(request); // JWT 토큰 추출
-
-		try {
-			if (token != null && jwtTokenProvider.validateToken(token)) {
-				// 토큰 유효
-				Authentication auth = jwtTokenProvider.getAuthentication(token);
-				SecurityContextHolder.getContext().setAuthentication(auth); // 생성된 Authentication 객체를
-																			// SecurityContextHolder 에 설정
-			}
-		} catch (JWTVerificationException | IllegalArgumentException e) {
-			// JWTVerificationException : JWT 유효 x | 서명 잘못됨
-			// IllegalArgumentException : 잘못된 인자 전달
-			logger.error(e.getMessage());
-
-			response.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // 인증 실패 - 401 코드 반환
-			response.getWriter().write("doFilterInternal() - Invalid JWT token");
-
-			return;
-		}
-		chain.doFilter(request, response);
-	}
+//	@Override
+//	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+//			throws ServletException, IOException {
+//
+//		String token = resolveToken(request); // JWT 토큰 추출
+//
+//		try {
+//			if (token != null && jwtTokenProvider.validateToken(token)) {
+//				// 토큰 유효
+//				Authentication auth = jwtTokenProvider.getAuthentication(token);
+//				SecurityContextHolder.getContext().setAuthentication(auth); // 생성된 Authentication 객체를
+//																			// SecurityContextHolder 에 설정
+//			}
+//		} catch (JWTVerificationException | IllegalArgumentException e) {
+//			// JWTVerificationException : JWT 유효 x | 서명 잘못됨
+//			// IllegalArgumentException : 잘못된 인자 전달
+//			logger.error(e.getMessage());
+//
+//			response.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // 인증 실패 - 401 코드 반환
+//			response.getWriter().write("doFilterInternal() - Invalid JWT token");
+//
+//			return;
+//		}
+//		chain.doFilter(request, response);
+//	}
 
 	private String resolveToken(HttpServletRequest request) {
 		String bearerToken = request.getHeader("Authorization");
 		logger.info("📌 Authorization 헤더: " + bearerToken); // ✅ 추가 로그
 		return (bearerToken != null && bearerToken.startsWith("Bearer ")) ? bearerToken.substring(7) : null;
+	}
+	
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws ServletException, IOException {
+		// 쿠키에서 토큰 추출
+		Optional<Cookie> accessToken = getCookie(request, "AT");
+		if (accessToken.isPresent()) {
+			boolean validToken = jwtTokenProvider.validateToken(String.valueOf(accessToken.get().getValue()));
+			UsernamePasswordAuthenticationToken authentication;
+			if (validToken) {
+				authentication = jwtTokenProvider.createAuthenticationFromToken(String.valueOf(accessToken.get().getValue()));
+			} else {
+				authentication = jwtTokenProvider.replaceAccessToken(response, accessToken.get().getValue());
+			}
+			SecurityContextHolder.getContext().setAuthentication(authentication);
+		}
+		chain.doFilter(request, response);
+	}
+	
+	private Optional<Cookie> getCookie(HttpServletRequest request, String name) {
+		Cookie[] cookies = request.getCookies();
+		if (cookies != null && cookies.length > 0) {
+			for (Cookie cookie : cookies) {
+				if (cookie.getName().equals(name)) {
+					return Optional.of(cookie);
+				}
+			}
+		}
+		return Optional.empty();
 	}
 }

--- a/src/main/java/cinebox/security/JwtAuthenticationFilter.java
+++ b/src/main/java/cinebox/security/JwtAuthenticationFilter.java
@@ -4,11 +4,8 @@ import java.io.IOException;
 import java.util.Optional;
 
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
-
-import com.auth0.jwt.exceptions.JWTVerificationException;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -16,69 +13,46 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
-	private final JwtTokenProvider jwtTokenProvider;
+    private final JwtTokenProvider jwtTokenProvider;
 
-//	@Override
-//	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
-//			throws ServletException, IOException {
-//
-//		String token = resolveToken(request); // JWT 토큰 추출
-//
-//		try {
-//			if (token != null && jwtTokenProvider.validateToken(token)) {
-//				// 토큰 유효
-//				Authentication auth = jwtTokenProvider.getAuthentication(token);
-//				SecurityContextHolder.getContext().setAuthentication(auth); // 생성된 Authentication 객체를
-//																			// SecurityContextHolder 에 설정
-//			}
-//		} catch (JWTVerificationException | IllegalArgumentException e) {
-//			// JWTVerificationException : JWT 유효 x | 서명 잘못됨
-//			// IllegalArgumentException : 잘못된 인자 전달
-//			logger.error(e.getMessage());
-//
-//			response.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // 인증 실패 - 401 코드 반환
-//			response.getWriter().write("doFilterInternal() - Invalid JWT token");
-//
-//			return;
-//		}
-//		chain.doFilter(request, response);
-//	}
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+            throws ServletException, IOException {
+        log.debug("## doFilterInternal 동작...");
+        // 쿠키에서 액세스 토큰과 리프레시 토큰 추출
+        Optional<Cookie> accessTokenCookie = getCookie(request, "AT");
+        Optional<Cookie> refreshTokenCookie = getCookie(request, "RT");
 
-	private String resolveToken(HttpServletRequest request) {
-		String bearerToken = request.getHeader("Authorization");
-		logger.info("📌 Authorization 헤더: " + bearerToken); // ✅ 추가 로그
-		return (bearerToken != null && bearerToken.startsWith("Bearer ")) ? bearerToken.substring(7) : null;
-	}
-	
-	@Override
-	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws ServletException, IOException {
-		// 쿠키에서 토큰 추출
-		Optional<Cookie> accessToken = getCookie(request, "AT");
-		if (accessToken.isPresent()) {
-			boolean validToken = jwtTokenProvider.validateToken(String.valueOf(accessToken.get().getValue()));
-			UsernamePasswordAuthenticationToken authentication;
-			if (validToken) {
-				authentication = jwtTokenProvider.createAuthenticationFromToken(String.valueOf(accessToken.get().getValue()));
-			} else {
-				authentication = jwtTokenProvider.replaceAccessToken(response, accessToken.get().getValue());
-			}
-			SecurityContextHolder.getContext().setAuthentication(authentication);
-		}
-		chain.doFilter(request, response);
-	}
-	
-	private Optional<Cookie> getCookie(HttpServletRequest request, String name) {
-		Cookie[] cookies = request.getCookies();
-		if (cookies != null && cookies.length > 0) {
-			for (Cookie cookie : cookies) {
-				if (cookie.getName().equals(name)) {
-					return Optional.of(cookie);
-				}
-			}
-		}
+        UsernamePasswordAuthenticationToken authentication = null;
+
+        if (accessTokenCookie.isPresent() && jwtTokenProvider.validateToken(accessTokenCookie.get().getValue())) {
+            // 유효한 액세스 토큰이 있는 경우
+            authentication = jwtTokenProvider.createAuthenticationFromToken(accessTokenCookie.get().getValue());
+        } else if (refreshTokenCookie.isPresent() && jwtTokenProvider.validateToken(refreshTokenCookie.get().getValue())) {
+            // 액세스 토큰이 없거나 만료되었을 때, 리프레시 토큰으로 재발급 시도
+            authentication = jwtTokenProvider.replaceAccessToken(response, refreshTokenCookie.get().getValue());
+        }
+
+        if (authentication != null) {
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+        chain.doFilter(request, response);
+    }
+    
+    private Optional<Cookie> getCookie(HttpServletRequest request, String name) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null && cookies.length > 0) {
+            for (Cookie cookie : cookies) {
+                if (cookie.getName().equals(name)) {
+                    return Optional.of(cookie);
+                }
+            }
+        }
 		return Optional.empty();
 	}
 }

--- a/src/main/java/cinebox/security/JwtTokenProvider.java
+++ b/src/main/java/cinebox/security/JwtTokenProvider.java
@@ -1,21 +1,30 @@
 package cinebox.security;
 
+import java.io.IOException;
 import java.util.Date;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.exceptions.JWTVerificationException;
+import com.auth0.jwt.exceptions.TokenExpiredException;
 import com.auth0.jwt.interfaces.Claim;
 import com.auth0.jwt.interfaces.DecodedJWT;
 
+import cinebox.common.exception.auth.NotFoundTokenException;
 import cinebox.common.exception.user.NotFoundUserException;
+import cinebox.entity.TokenRedis;
+import cinebox.repository.TokenRedisRepository;
 import cinebox.repository.UserRepository;
+import io.lettuce.core.RedisException;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 
 @Component
@@ -28,23 +37,25 @@ public class JwtTokenProvider {
 	@Value("${security.jwt.validityInMilliseconds}")
     private long validityInMilliseconds;
 
-    public String createToken(Long user_id, String role) {
-        return JWT.create()
-                .withClaim("user_id", user_id) 
-                .withClaim("role", role)
-                .withExpiresAt(new Date(System.currentTimeMillis() + validityInMilliseconds))
-                .sign(Algorithm.HMAC256(secretKey));
-    }
-    
-    public String getToken (HttpServletRequest request) {
-        String bearerToken = request.getHeader("Authorization");
-        return (bearerToken != null && bearerToken.startsWith("Bearer ")) ? bearerToken.substring(7) : null;
-    }
+//    public String createToken(Long user_id, String role) {
+//        return JWT.create()
+//                .withClaim("user_id", user_id) 
+//                .withClaim("role", role)
+//                .withExpiresAt(new Date(System.currentTimeMillis() + validityInMilliseconds))
+//                .sign(Algorithm.HMAC256(secretKey));
+//    }
+//    
+//    public String getToken (HttpServletRequest request) {
+//        String bearerToken = request.getHeader("Authorization");
+//        return (bearerToken != null && bearerToken.startsWith("Bearer ")) ? bearerToken.substring(7) : null;
+//    }
     
     public boolean validateToken(String token) {
         try {
             JWT.require(Algorithm.HMAC256(secretKey)).build().verify(token);
             return true;
+        } catch(TokenExpiredException e) {
+        	return false;
         } catch (JWTVerificationException e) {
             System.out.println(secretKey);
             return false;
@@ -67,4 +78,81 @@ public class JwtTokenProvider {
         return new UsernamePasswordAuthenticationToken(principalDetails, "", principalDetails.getAuthorities());
     }
     
+    
+    
+    
+    
+    
+    @Value("${security.jwt.accessTokenValidityInMilliseconds}")
+    public long accessTokenValidityInMilliseconds;
+    
+    @Value("${security.jwt.refreshTokenValidityInMilliseconds}")
+    public long refreshTokenValidityInMilliseconds;
+    
+    public String createAccessToken(Long userId, String role) {
+    	Date now = new Date();
+    	Date validity = new Date(now.getTime() + accessTokenValidityInMilliseconds);
+    	return JWT.create()
+    			.withClaim("user_id", userId)
+    			.withClaim("role", role)
+    			.withIssuedAt(now)
+    			.withExpiresAt(validity)
+    			.sign(Algorithm.HMAC256(secretKey));
+    }
+    
+    public String createRefreshToken(Long userId, String role) {
+    	Date now = new Date();
+    	Date validity = new Date(now.getTime() + refreshTokenValidityInMilliseconds);
+    	return JWT.create()
+    			.withClaim("user_id", userId)
+    			.withClaim("role", role)
+    			.withIssuedAt(now)
+    			.withExpiresAt(validity)
+    			.sign(Algorithm.HMAC256(secretKey));
+    }
+    
+    private final PrincipalDetailsService principalDetailsService;
+    private final TokenRedisRepository tokenRedisRepository;
+    
+    public UsernamePasswordAuthenticationToken createAuthenticationFromToken(String token) {
+    	Authentication authentication = getAuthentication(token);
+    	UserDetails userDetails = principalDetailsService.loadUserByUsername(authentication.getName());
+    	
+    	return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+    }
+    
+    public void saveCookie(HttpServletResponse response, String accessToken) {
+    	Cookie cookie = new Cookie("AT", accessToken);
+    	cookie.setHttpOnly(true);
+    	cookie.setPath("/");
+    	cookie.setMaxAge((int)(accessTokenValidityInMilliseconds / 1000));
+    	response.addCookie(cookie);
+    }
+    
+    public UsernamePasswordAuthenticationToken replaceAccessToken(HttpServletResponse response, String refreshToken) throws IOException {
+        try {
+            // Refresh Token 검증
+            DecodedJWT decodedRefresh = JWT.require(Algorithm.HMAC256(secretKey)).build().verify(refreshToken);
+            Long userId = decodedRefresh.getClaim("user_id").asLong();
+            String role = decodedRefresh.getClaim("role").asString();
+            
+            // 새 Access Token 생성
+            String newAccessToken = createAccessToken(userId, role);
+            // 쿠키에 저장
+            saveCookie(response, newAccessToken);
+            
+            // Redis에 저장된 토큰 업데이트 (사용자 ID를 key로 저장했다고 가정)
+            TokenRedis tokenRedis = tokenRedisRepository.findById(String.valueOf(userId))
+                .orElseThrow(() -> NotFoundTokenException.EXCEPTION);
+            tokenRedis.updateAccessToken(newAccessToken);
+            tokenRedisRepository.save(tokenRedis);
+            
+            return createAuthenticationFromToken(newAccessToken);
+        } catch (TokenExpiredException | NotFoundTokenException e) {
+            response.sendRedirect("/error");
+        } catch (RedisException redisException) {
+            response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "Redis 서버 에러");
+        }
+        return null;
+    }
 }

--- a/src/main/java/cinebox/security/JwtTokenProvider.java
+++ b/src/main/java/cinebox/security/JwtTokenProvider.java
@@ -23,136 +23,141 @@ import cinebox.repository.TokenRedisRepository;
 import cinebox.repository.UserRepository;
 import io.lettuce.core.RedisException;
 import jakarta.servlet.http.Cookie;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class JwtTokenProvider {
 	private final UserRepository userRepository;
+	private final PrincipalDetailsService principalDetailsService;
+	private final TokenRedisRepository tokenRedisRepository;
 
 	@Value("${security.jwt.secretkey}")
-    private String secretKey;
-	@Value("${security.jwt.validityInMilliseconds}")
-    private long validityInMilliseconds;
+	private String secretKey;
 
-//    public String createToken(Long user_id, String role) {
-//        return JWT.create()
-//                .withClaim("user_id", user_id) 
-//                .withClaim("role", role)
-//                .withExpiresAt(new Date(System.currentTimeMillis() + validityInMilliseconds))
-//                .sign(Algorithm.HMAC256(secretKey));
-//    }
-//    
-//    public String getToken (HttpServletRequest request) {
-//        String bearerToken = request.getHeader("Authorization");
-//        return (bearerToken != null && bearerToken.startsWith("Bearer ")) ? bearerToken.substring(7) : null;
-//    }
-    
-    public boolean validateToken(String token) {
-        try {
-            JWT.require(Algorithm.HMAC256(secretKey)).build().verify(token);
-            return true;
-        } catch(TokenExpiredException e) {
-        	return false;
-        } catch (JWTVerificationException e) {
-            System.out.println(secretKey);
-            return false;
-        }
-    }
-    
-    public Claim getClaim (String token, String Claim) {
-    	DecodedJWT decodedJWT = JWT.require(Algorithm.HMAC256(secretKey)).build().verify(token);
-    	return decodedJWT.getClaim(Claim);
-    }
-    
-    public Authentication getAuthentication(String token) {
-    	DecodedJWT decodedJWT = JWT.require(Algorithm.HMAC256(secretKey)).build().verify(token);
+	@Value("${security.jwt.accessTokenValidityInMilliseconds}")
+	public long accessTokenValidityInMilliseconds;
 
-        Long userId = decodedJWT.getClaim("user_id").asLong();
-        cinebox.entity.User user = userRepository.findByUserIdAndIsDeletedFalse(userId).orElseThrow(() -> NotFoundUserException.EXCEPTION);
-        String role = decodedJWT.getClaim("role").asString();
-        
-        PrincipalDetails principalDetails = new PrincipalDetails(user);
-        return new UsernamePasswordAuthenticationToken(principalDetails, "", principalDetails.getAuthorities());
-    }
-    
-    
-    
-    
-    
-    
-    @Value("${security.jwt.accessTokenValidityInMilliseconds}")
-    public long accessTokenValidityInMilliseconds;
-    
-    @Value("${security.jwt.refreshTokenValidityInMilliseconds}")
-    public long refreshTokenValidityInMilliseconds;
-    
-    public String createAccessToken(Long userId, String role) {
-    	Date now = new Date();
-    	Date validity = new Date(now.getTime() + accessTokenValidityInMilliseconds);
-    	return JWT.create()
-    			.withClaim("user_id", userId)
-    			.withClaim("role", role)
-    			.withIssuedAt(now)
-    			.withExpiresAt(validity)
-    			.sign(Algorithm.HMAC256(secretKey));
-    }
-    
-    public String createRefreshToken(Long userId, String role) {
-    	Date now = new Date();
-    	Date validity = new Date(now.getTime() + refreshTokenValidityInMilliseconds);
-    	return JWT.create()
-    			.withClaim("user_id", userId)
-    			.withClaim("role", role)
-    			.withIssuedAt(now)
-    			.withExpiresAt(validity)
-    			.sign(Algorithm.HMAC256(secretKey));
-    }
-    
-    private final PrincipalDetailsService principalDetailsService;
-    private final TokenRedisRepository tokenRedisRepository;
-    
-    public UsernamePasswordAuthenticationToken createAuthenticationFromToken(String token) {
-    	Authentication authentication = getAuthentication(token);
-    	UserDetails userDetails = principalDetailsService.loadUserByUsername(authentication.getName());
-    	
-    	return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
-    }
-    
-    public void saveCookie(HttpServletResponse response, String accessToken) {
-    	Cookie cookie = new Cookie("AT", accessToken);
-    	cookie.setHttpOnly(true);
-    	cookie.setPath("/");
-    	cookie.setMaxAge((int)(accessTokenValidityInMilliseconds / 1000));
-    	response.addCookie(cookie);
-    }
-    
-    public UsernamePasswordAuthenticationToken replaceAccessToken(HttpServletResponse response, String refreshToken) throws IOException {
-        try {
-            // Refresh Token 검증
-            DecodedJWT decodedRefresh = JWT.require(Algorithm.HMAC256(secretKey)).build().verify(refreshToken);
-            Long userId = decodedRefresh.getClaim("user_id").asLong();
-            String role = decodedRefresh.getClaim("role").asString();
-            
-            // 새 Access Token 생성
-            String newAccessToken = createAccessToken(userId, role);
-            // 쿠키에 저장
-            saveCookie(response, newAccessToken);
-            
-            // Redis에 저장된 토큰 업데이트 (사용자 ID를 key로 저장했다고 가정)
-            TokenRedis tokenRedis = tokenRedisRepository.findById(String.valueOf(userId))
-                .orElseThrow(() -> NotFoundTokenException.EXCEPTION);
-            tokenRedis.updateAccessToken(newAccessToken);
-            tokenRedisRepository.save(tokenRedis);
-            
-            return createAuthenticationFromToken(newAccessToken);
-        } catch (TokenExpiredException | NotFoundTokenException e) {
-            response.sendRedirect("/error");
-        } catch (RedisException redisException) {
-            response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "Redis 서버 에러");
-        }
-        return null;
-    }
+	@Value("${security.jwt.refreshTokenValidityInMilliseconds}")
+	public long refreshTokenValidityInMilliseconds;
+
+	public String createAccessToken(Long userId, String role) {
+		Date now = new Date();
+		Date validity = new Date(now.getTime() + accessTokenValidityInMilliseconds);
+		return JWT.create().withClaim("user_id", userId).withClaim("role", role).withIssuedAt(now)
+				.withExpiresAt(validity).sign(Algorithm.HMAC256(secretKey));
+	}
+
+	public String createRefreshToken(Long userId, String role) {
+		Date now = new Date();
+		Date validity = new Date(now.getTime() + refreshTokenValidityInMilliseconds);
+		return JWT.create().withClaim("user_id", userId).withClaim("role", role).withIssuedAt(now)
+				.withExpiresAt(validity).sign(Algorithm.HMAC256(secretKey));
+	}
+
+	public boolean validateToken(String token) {
+		try {
+			JWT.require(Algorithm.HMAC256(secretKey)).build().verify(token);
+			return true;
+		} catch (TokenExpiredException e) {
+			return false;
+		} catch (JWTVerificationException e) {
+			log.error("토큰 검증 실패, secretKey: {}", secretKey);
+			return false;
+		}
+	}
+
+	public Claim getClaim(String token, String claimName) {
+		DecodedJWT decodedJWT = JWT.require(Algorithm.HMAC256(secretKey)).build().verify(token);
+		return decodedJWT.getClaim(claimName);
+	}
+
+	public Authentication getAuthentication(String token) {
+		DecodedJWT decodedJWT = JWT.require(Algorithm.HMAC256(secretKey)).build().verify(token);
+		Long userId = decodedJWT.getClaim("user_id").asLong();
+		cinebox.entity.User user = userRepository.findByUserIdAndIsDeletedFalse(userId)
+				.orElseThrow(() -> NotFoundUserException.EXCEPTION);
+		PrincipalDetails principalDetails = new PrincipalDetails(user);
+		return new UsernamePasswordAuthenticationToken(principalDetails, "", principalDetails.getAuthorities());
+	}
+
+	public UsernamePasswordAuthenticationToken createAuthenticationFromToken(String token) {
+		Authentication authentication = getAuthentication(token);
+		UserDetails userDetails = principalDetailsService.loadUserByUsername(authentication.getName());
+		return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+	}
+
+	/**
+	 * 액세스 토큰을 쿠키에 저장합니다.
+	 */
+	public void saveAccessCookie(HttpServletResponse response, String accessToken) {
+		Cookie cookie = new Cookie("AT", accessToken);
+		cookie.setHttpOnly(true);
+		cookie.setPath("/");
+		cookie.setMaxAge((int) (accessTokenValidityInMilliseconds / 1000));
+		response.addCookie(cookie);
+	}
+
+	/**
+	 * 리프레시 토큰을 쿠키에 저장합니다.
+	 */
+	public void saveRefreshCookie(HttpServletResponse response, String refreshToken) {
+		Cookie cookie = new Cookie("RT", refreshToken);
+		cookie.setHttpOnly(true);
+		cookie.setPath("/");
+		cookie.setMaxAge((int) (refreshTokenValidityInMilliseconds / 1000));
+		response.addCookie(cookie);
+	}
+
+	/**
+	 * 액세스 토큰이 만료된 경우, 리프레시 토큰을 이용해 새로운 액세스 토큰을 발급합니다.
+	 */
+	public UsernamePasswordAuthenticationToken replaceAccessToken(HttpServletResponse response, String refreshToken)
+			throws IOException {
+		try {
+			// 리프레시 토큰 검증
+			DecodedJWT decodedRefresh = JWT.require(Algorithm.HMAC256(secretKey)).build().verify(refreshToken);
+			Long userId = decodedRefresh.getClaim("user_id").asLong();
+			String role = decodedRefresh.getClaim("role").asString();
+
+			// Redis 엔티티 조회 및 리프레시 토큰 일치 여부 확인
+			TokenRedis tokenRedis = tokenRedisRepository.findById(String.valueOf(userId))
+					.orElseThrow(() -> NotFoundTokenException.EXCEPTION);
+
+			if (!tokenRedis.getRefreshToken().equals(refreshToken)) {
+				log.error("리프레시 토큰 불일치: Redis에 저장된 토큰과 요청된 토큰이 다릅니다.");
+				response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Refresh token mismatch. Please login again.");
+				return null;
+			}
+
+			log.info("## 토큰 재발급 시작... userId: {}", userId);
+
+			UsernamePasswordAuthenticationToken authentication = createAuthenticationFromToken(refreshToken);
+			// 새 액세스 토큰 발급
+			String newAccessToken = createAccessToken(userId, role);
+
+			// 쿠키에 새 액세스 토큰 저장
+			saveAccessCookie(response, newAccessToken);
+			// Redis 업데이트
+			tokenRedis.updateAccessToken(newAccessToken);
+			tokenRedisRepository.save(tokenRedis);
+
+			log.info("## 토큰 재발급 완료. userId: {}", userId);
+
+			return authentication;
+		} catch (JWTVerificationException e) {
+			log.error("리프레시 토큰 검증 실패: {}", e.getMessage());
+			response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Refresh token expired or invalid.");
+		} catch (NotFoundTokenException e) {
+			log.error("Redis 토큰 조회 실패: {}", e.getMessage());
+			response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Token not found. Please login again.");
+		} catch (RedisException redisException) {
+			log.error("Redis 서버 에러: {}", redisException.getMessage());
+			response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "Redis 서버 에러");
+		}
+		return null;
+	}
 }

--- a/src/main/java/cinebox/security/config/RedisRepositoryConfig.java
+++ b/src/main/java/cinebox/security/config/RedisRepositoryConfig.java
@@ -1,0 +1,25 @@
+package cinebox.security.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisKeyValueAdapter;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+
+@Configuration
+@EnableRedisRepositories(enableKeyspaceEvents = RedisKeyValueAdapter.EnableKeyspaceEvents.ON_STARTUP)
+public class RedisRepositoryConfig {
+	@Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+    
+    @Bean
+    public LettuceConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration configuration = new RedisStandaloneConfiguration(host, port);
+        return new LettuceConnectionFactory(configuration);
+    }
+}

--- a/src/main/java/cinebox/security/config/RedisRepositoryConfig.java
+++ b/src/main/java/cinebox/security/config/RedisRepositoryConfig.java
@@ -12,14 +12,14 @@ import org.springframework.data.redis.repository.configuration.EnableRedisReposi
 @EnableRedisRepositories(enableKeyspaceEvents = RedisKeyValueAdapter.EnableKeyspaceEvents.ON_STARTUP)
 public class RedisRepositoryConfig {
 	@Value("${spring.data.redis.host}")
-    private String host;
+	private String host;
 
-    @Value("${spring.data.redis.port}")
-    private int port;
-    
-    @Bean
-    public LettuceConnectionFactory redisConnectionFactory() {
-        RedisStandaloneConfiguration configuration = new RedisStandaloneConfiguration(host, port);
-        return new LettuceConnectionFactory(configuration);
-    }
+	@Value("${spring.data.redis.port}")
+	private int port;
+
+	@Bean
+	public LettuceConnectionFactory redisConnectionFactory() {
+		RedisStandaloneConfiguration configuration = new RedisStandaloneConfiguration(host, port);
+		return new LettuceConnectionFactory(configuration);
+	}
 }

--- a/src/main/java/cinebox/service/AuthService.java
+++ b/src/main/java/cinebox/service/AuthService.java
@@ -1,0 +1,16 @@
+package cinebox.service;
+
+import cinebox.dto.request.AuthRequest;
+import cinebox.dto.request.UserRequest;
+import cinebox.dto.response.AuthResponse;
+import cinebox.dto.response.UserResponse;
+import jakarta.servlet.http.HttpServletResponse;
+
+public interface AuthService {
+
+	// 회원가입
+	UserResponse signup(UserRequest request);
+
+	// 로그인
+	AuthResponse login(AuthRequest request, HttpServletResponse response);
+}

--- a/src/main/java/cinebox/service/AuthServiceImpl.java
+++ b/src/main/java/cinebox/service/AuthServiceImpl.java
@@ -1,5 +1,7 @@
 package cinebox.service;
 
+import java.util.Optional;
+
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -7,6 +9,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import cinebox.common.exception.auth.NotFoundTokenException;
 import cinebox.common.exception.user.DuplicateUserException;
 import cinebox.dto.request.AuthRequest;
 import cinebox.dto.request.UserRequest;
@@ -62,8 +65,8 @@ public class AuthServiceImpl implements AuthService {
 		TokenRedis tokenRedis = new TokenRedis(String.valueOf(user.getUserId()), accessToken, refreshToken);
 		tokenRedisRepository.save(tokenRedis);
 
-		jwtTokenProvider.saveCookie(response, accessToken);
+		jwtTokenProvider.saveAccessCookie(response, accessToken);
+		jwtTokenProvider.saveRefreshCookie(response, refreshToken);
 		return new AuthResponse(accessToken, refreshToken);
 	}
-
 }

--- a/src/main/java/cinebox/service/AuthServiceImpl.java
+++ b/src/main/java/cinebox/service/AuthServiceImpl.java
@@ -67,6 +67,6 @@ public class AuthServiceImpl implements AuthService {
 
 		jwtTokenProvider.saveAccessCookie(response, accessToken);
 		jwtTokenProvider.saveRefreshCookie(response, refreshToken);
-		return new AuthResponse(user.getUserId(), user.getRole().toString(), user.getIdentifier(), accessToken, refreshToken);
+		return new AuthResponse(user.getUserId(), user.getRole().toString(), user.getIdentifier());
 	}
 }

--- a/src/main/java/cinebox/service/AuthServiceImpl.java
+++ b/src/main/java/cinebox/service/AuthServiceImpl.java
@@ -1,0 +1,69 @@
+package cinebox.service;
+
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import cinebox.common.exception.user.DuplicateUserException;
+import cinebox.dto.request.AuthRequest;
+import cinebox.dto.request.UserRequest;
+import cinebox.dto.response.AuthResponse;
+import cinebox.dto.response.UserResponse;
+import cinebox.entity.TokenRedis;
+import cinebox.entity.User;
+import cinebox.repository.TokenRedisRepository;
+import cinebox.repository.UserRepository;
+import cinebox.security.JwtTokenProvider;
+import cinebox.security.PrincipalDetails;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class AuthServiceImpl implements AuthService {
+	
+	private final UserRepository userRepository;
+	private final PasswordEncoder passwordEncoder;
+	private final JwtTokenProvider jwtTokenProvider;
+	private final AuthenticationManager authenticationManager;
+	private final TokenRedisRepository tokenRedisRepository;
+
+	@Override
+	@Transactional
+	public UserResponse signup(UserRequest request) {
+		boolean isDuplicatedIdentifier = userRepository.findByIdentifier(request.getIdentifier()).isPresent();
+        if(isDuplicatedIdentifier) {
+        	throw DuplicateUserException.EXCEPTION;
+        }
+        
+        String encodedPassword = passwordEncoder.encode(request.getPassword());
+        request.setPassword(encodedPassword);
+		User newUser = User.of(request);
+
+		userRepository.save(newUser);
+		return UserResponse.from(newUser);
+	}
+
+	@Override
+	@Transactional
+	public AuthResponse login(AuthRequest request, HttpServletResponse response) {
+		UsernamePasswordAuthenticationToken token = new UsernamePasswordAuthenticationToken(request.getIdentifier(), request.getPassword());
+		Authentication authentication = authenticationManager.authenticate(token);
+		
+		PrincipalDetails principal = (PrincipalDetails) authentication.getPrincipal();
+		User user = principal.getUser();
+		
+		String accessToken = jwtTokenProvider.createAccessToken(user.getUserId(), user.getRole().name());
+		String refreshToken = jwtTokenProvider.createRefreshToken(user.getUserId(), user.getRole().name());
+		
+		TokenRedis tokenRedis = new TokenRedis(String.valueOf(user.getUserId()), accessToken, refreshToken);
+		tokenRedisRepository.save(tokenRedis);
+
+		jwtTokenProvider.saveCookie(response, accessToken);
+		return new AuthResponse(accessToken, refreshToken);
+	}
+
+}

--- a/src/main/java/cinebox/service/AuthServiceImpl.java
+++ b/src/main/java/cinebox/service/AuthServiceImpl.java
@@ -67,6 +67,6 @@ public class AuthServiceImpl implements AuthService {
 
 		jwtTokenProvider.saveAccessCookie(response, accessToken);
 		jwtTokenProvider.saveRefreshCookie(response, refreshToken);
-		return new AuthResponse(accessToken, refreshToken);
+		return new AuthResponse(user.getUserId(), user.getRole().toString(), user.getIdentifier(), accessToken, refreshToken);
 	}
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

#55 

## 📝작업 내용

- JWT Access Token, Refresh Token 생성
- Redis에 Refresh Token 저장
- Cookie에 AT, RT 저장
- AT가 만료되면 RT를 통해 AT 재발급

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
