### PR TITLE
Fix(#74): Refresh token ttl 이슈 해결

### DIFF
--- a/src/main/java/cinebox/security/JwtTokenProvider.java
+++ b/src/main/java/cinebox/security/JwtTokenProvider.java
@@ -4,6 +4,8 @@ import java.io.IOException;
 import java.util.Date;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.PartialUpdate;
+import org.springframework.data.redis.core.RedisKeyValueTemplate;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -34,6 +36,7 @@ public class JwtTokenProvider {
 	private final UserRepository userRepository;
 	private final PrincipalDetailsService principalDetailsService;
 	private final TokenRedisRepository tokenRedisRepository;
+	private final RedisKeyValueTemplate redisKeyValueTemplate;
 
 	@Value("${security.jwt.secretkey}")
 	private String secretKey;
@@ -142,8 +145,8 @@ public class JwtTokenProvider {
 			// 쿠키에 새 액세스 토큰 저장
 			saveAccessCookie(response, newAccessToken);
 			// Redis 업데이트
-			tokenRedis.updateAccessToken(newAccessToken);
-			tokenRedisRepository.save(tokenRedis);
+			PartialUpdate<TokenRedis> update = new PartialUpdate<>(String.valueOf(userId), TokenRedis.class).set("accessToken", newAccessToken);
+            redisKeyValueTemplate.update(update);
 
 			log.info("## 토큰 재발급 완료. userId: {}", userId);
 

--- a/src/main/java/cinebox/security/config/RedisRepositoryConfig.java
+++ b/src/main/java/cinebox/security/config/RedisRepositoryConfig.java
@@ -3,10 +3,16 @@ package cinebox.security.config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisKeyValueAdapter;
+import org.springframework.data.redis.core.RedisKeyValueTemplate;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.mapping.RedisMappingContext;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+
+import cinebox.entity.TokenRedis;
 
 @Configuration
 @EnableRedisRepositories(enableKeyspaceEvents = RedisKeyValueAdapter.EnableKeyspaceEvents.ON_STARTUP)
@@ -21,5 +27,13 @@ public class RedisRepositoryConfig {
 	public LettuceConnectionFactory redisConnectionFactory() {
 		RedisStandaloneConfiguration configuration = new RedisStandaloneConfiguration(host, port);
 		return new LettuceConnectionFactory(configuration);
+	}
+
+	@Bean
+	public RedisKeyValueTemplate redisKeyValueTemplate(RedisConnectionFactory redisConnectionFactory) {
+		RedisTemplate<String, TokenRedis> redisTemplate = new RedisTemplate<>();
+		redisTemplate.setConnectionFactory(redisConnectionFactory);
+		redisTemplate.afterPropertiesSet();
+		return new RedisKeyValueTemplate(new RedisKeyValueAdapter(redisTemplate), new RedisMappingContext());
 	}
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

#74 

## 📝작업 내용

- RedisTemplate의 Partial Update를 통해 Refresh Token의 TTL이 갱신되지 않고 업데이트되도록 구현

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
