### PR TITLE
Feat(#80): 로그아웃 및 탈퇴에 대한 토큰 처리 기능 구현

### DIFF
--- a/src/main/java/cinebox/common/exception/BaseException.java
+++ b/src/main/java/cinebox/common/exception/BaseException.java
@@ -12,18 +12,10 @@ public abstract class BaseException extends RuntimeException {
 		this.title = message.getTitle();
 	}
 
-	// 추가 
-    public BaseException(String message, HttpStatus status) {
-        super(message);
-        this.status = status;
-        this.title = null; // Or you can provide a default title if needed
-    }
-
-    
 	public HttpStatus getStatus() {
 		return status;
 	}
-	
+
 	public String getTitle() {
 		return title;
 	}

--- a/src/main/java/cinebox/common/exception/ExceptionMessage.java
+++ b/src/main/java/cinebox/common/exception/ExceptionMessage.java
@@ -9,7 +9,9 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ExceptionMessage {
 	// auth
-	NOT_FOUND_TOKEN("다시 로그인 해 주세요.", HttpStatus.NOT_FOUND, "Not Found Token"),
+	NOT_FOUND_TOKEN("토큰을 조회할 수 없습니다. 다시 로그인 해 주세요.", HttpStatus.UNAUTHORIZED, "Not Found Token"),
+	INVALID_TOKEN("유효하지 않은 토큰입니다. 다시 로그인 해 주세요.", HttpStatus.UNAUTHORIZED, "Invaled Token"),
+	REDIS_SERVER_ERROR("Redis 서버 에러 발생", HttpStatus.INTERNAL_SERVER_ERROR, "Redis Server Error"),
 	
 	// user
 	NOT_FOUND_USER("유효하지 않은 UserId 입니다.", HttpStatus.NOT_FOUND, "Not Found UserId"),

--- a/src/main/java/cinebox/common/exception/auth/InvalidTokenException.java
+++ b/src/main/java/cinebox/common/exception/auth/InvalidTokenException.java
@@ -1,0 +1,13 @@
+package cinebox.common.exception.auth;
+
+import cinebox.common.exception.BaseException;
+import cinebox.common.exception.ExceptionMessage;
+
+public class InvalidTokenException extends BaseException {
+	public static final BaseException EXCEPTION = new InvalidTokenException();
+	
+	private InvalidTokenException() {
+		super(ExceptionMessage.INVALID_TOKEN);
+	
+	}
+}

--- a/src/main/java/cinebox/common/exception/auth/NotFoundTokenException.java
+++ b/src/main/java/cinebox/common/exception/auth/NotFoundTokenException.java
@@ -2,7 +2,6 @@ package cinebox.common.exception.auth;
 
 import cinebox.common.exception.BaseException;
 import cinebox.common.exception.ExceptionMessage;
-import cinebox.common.exception.booking.NotFoundBookingException;
 
 public class NotFoundTokenException extends BaseException {
 	public static final BaseException EXCEPTION = new NotFoundTokenException();

--- a/src/main/java/cinebox/common/exception/auth/RedisServerException.java
+++ b/src/main/java/cinebox/common/exception/auth/RedisServerException.java
@@ -1,0 +1,13 @@
+package cinebox.common.exception.auth;
+
+import cinebox.common.exception.BaseException;
+import cinebox.common.exception.ExceptionMessage;
+
+public class RedisServerException extends BaseException {
+	public static final BaseException EXCEPTION = new RedisServerException();
+
+	private RedisServerException() {
+		super(ExceptionMessage.REDIS_SERVER_ERROR);
+
+	}
+}

--- a/src/main/java/cinebox/common/utils/CookieUtil.java
+++ b/src/main/java/cinebox/common/utils/CookieUtil.java
@@ -1,0 +1,36 @@
+package cinebox.common.utils;
+
+import java.util.Optional;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+public class CookieUtil {
+	public static Optional<Cookie> getCookie(HttpServletRequest request, String name) {
+		Cookie[] cookies = request.getCookies();
+		if (cookies != null && cookies.length > 0) {
+			for (Cookie cookie : cookies) {
+				if (cookie.getName().equals(name)) {
+					return Optional.of(cookie);
+				}
+			}
+		}
+		return Optional.empty();
+	}
+	
+	public static void clearAuthCookies(HttpServletResponse response) {
+		Cookie accessTokenCookie = new Cookie("AT", "");
+		accessTokenCookie.setPath("/");
+		accessTokenCookie.setMaxAge(0);
+		accessTokenCookie.setHttpOnly(true);
+
+		Cookie refreshTokenCookie = new Cookie("RT", "");
+		refreshTokenCookie.setPath("/");
+		refreshTokenCookie.setMaxAge(0);
+		refreshTokenCookie.setHttpOnly(true);
+
+		response.addCookie(accessTokenCookie);
+		response.addCookie(refreshTokenCookie);
+	}
+}

--- a/src/main/java/cinebox/common/utils/SecurityUtil.java
+++ b/src/main/java/cinebox/common/utils/SecurityUtil.java
@@ -1,4 +1,4 @@
-package cinebox.security;
+package cinebox.common.utils;
 
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;

--- a/src/main/java/cinebox/domain/auth/controller/AuthController.java
+++ b/src/main/java/cinebox/domain/auth/controller/AuthController.java
@@ -2,7 +2,6 @@ package cinebox.domain.auth.controller;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -22,23 +21,24 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class AuthController {
 	private final AuthService authService;
-	
+
 	@PostMapping("/signup")
 	public ResponseEntity<UserResponse> signup(@RequestBody @Validated SignUpRequest user) {
 		UserResponse newUser = authService.signup(user);
 		return ResponseEntity.ok().body(newUser);
 	}
-	
+
 	@PostMapping("/login")
 	public ResponseEntity<AuthResponse> login(
 			@RequestBody AuthRequest authRequest,
 			HttpServletResponse response) {
 		AuthResponse authResponse = authService.login(authRequest, response);
-		return ResponseEntity.ok(authResponse);	
+		return ResponseEntity.ok(authResponse);
 	}
-	
-	@GetMapping("/logout")
-	public void logout(HttpServletRequest request) {
-		// 클라이언트가 스토리지 내부에 토큰을 지우고 로그인 페이지로 리다이렉트
+
+	@PostMapping("/logout")
+	public ResponseEntity<Void> logout(HttpServletRequest request, HttpServletResponse response) {
+		authService.logout(request, response);
+		return ResponseEntity.noContent().build();
 	}
 }

--- a/src/main/java/cinebox/domain/auth/service/AuthService.java
+++ b/src/main/java/cinebox/domain/auth/service/AuthService.java
@@ -4,6 +4,7 @@ import cinebox.domain.auth.dto.AuthRequest;
 import cinebox.domain.auth.dto.AuthResponse;
 import cinebox.domain.auth.dto.SignUpRequest;
 import cinebox.domain.user.dto.UserResponse;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 public interface AuthService {
@@ -13,4 +14,7 @@ public interface AuthService {
 
 	// 로그인
 	AuthResponse login(AuthRequest request, HttpServletResponse response);
+
+	// 로그아웃
+	void logout(HttpServletRequest request, HttpServletResponse response);
 }

--- a/src/main/java/cinebox/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/cinebox/domain/auth/service/AuthServiceImpl.java
@@ -85,13 +85,15 @@ public class AuthServiceImpl implements AuthService {
 
 	@Override
 	public void logout(HttpServletRequest request, HttpServletResponse response) {
-		CookieUtil.clearAuthCookies(response);
-		
+		// 블랙리스트에 액세스 토큰 등록 
 		Optional<Cookie> accessTokenCookie = CookieUtil.getCookie(request, "AT");
 		if (accessTokenCookie.isPresent()) {
 			String accessToken = accessTokenCookie.get().getValue();
 			jwtTokenProvider.addAccessTokenToBlacklist(accessToken);
 		}
+		
+		// 클라이언트 쿠키 삭제
+		CookieUtil.clearAuthCookies(response);
 	}
 
 	private void validateUniqueFields(SignUpRequest request) {

--- a/src/main/java/cinebox/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/cinebox/domain/auth/service/AuthServiceImpl.java
@@ -1,5 +1,7 @@
 package cinebox.domain.auth.service;
 
+import java.util.Optional;
+
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -8,11 +10,11 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import cinebox.common.exception.user.DuplicatedIdentifierException;
 import cinebox.common.enums.Role;
 import cinebox.common.exception.user.DuplicatedEmailException;
+import cinebox.common.exception.user.DuplicatedFieldException;
+import cinebox.common.exception.user.DuplicatedIdentifierException;
 import cinebox.common.exception.user.DuplicatedPhoneException;
-import cinebox.common.exception.user.NoAuthorizedUserException;
 import cinebox.domain.auth.dto.AuthRequest;
 import cinebox.domain.auth.dto.AuthResponse;
 import cinebox.domain.auth.dto.SignUpRequest;
@@ -21,10 +23,11 @@ import cinebox.domain.auth.repository.TokenRedisRepository;
 import cinebox.domain.user.dto.UserResponse;
 import cinebox.domain.user.entity.User;
 import cinebox.domain.user.repository.UserRepository;
-import cinebox.common.exception.user.DuplicatedFieldException;
 import cinebox.security.SecurityUtil;
 import cinebox.security.jwt.JwtTokenProvider;
 import cinebox.security.service.PrincipalDetails;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 
@@ -78,7 +81,18 @@ public class AuthServiceImpl implements AuthService {
 		jwtTokenProvider.saveRefreshCookie(response, refreshToken);
 		return new AuthResponse(user.getUserId(), user.getRole().toString(), user.getIdentifier());
 	}
-	
+
+	@Override
+	public void logout(HttpServletRequest request, HttpServletResponse response) {
+		clearAuthCookies(response);
+		
+		Optional<Cookie> accessTokenCookie = getCookie(request, "AT");
+		if (accessTokenCookie.isPresent()) {
+			String accessToken = accessTokenCookie.get().getValue();
+			jwtTokenProvider.addAccessTokenToBlacklist(accessToken);
+		}
+	}
+
 	private void validateUniqueFields(SignUpRequest request) {
 		if (userRepository.existsByIdentifier(request.identifier())) {
 			throw DuplicatedIdentifierException.EXCEPTION;
@@ -89,5 +103,32 @@ public class AuthServiceImpl implements AuthService {
 		if (userRepository.existsByPhone(request.phone())) {
 			throw DuplicatedPhoneException.EXCEPTION;
 		}
+	}
+
+	private void clearAuthCookies(HttpServletResponse response) {
+		Cookie accessTokenCookie = new Cookie("AT", "");
+		accessTokenCookie.setPath("/");
+		accessTokenCookie.setMaxAge(0);
+		accessTokenCookie.setHttpOnly(true);
+
+		Cookie refreshTokenCookie = new Cookie("RT", "");
+		refreshTokenCookie.setPath("/");
+		refreshTokenCookie.setMaxAge(0);
+		refreshTokenCookie.setHttpOnly(true);
+
+		response.addCookie(accessTokenCookie);
+		response.addCookie(refreshTokenCookie);
+	}
+
+	private Optional<Cookie> getCookie(HttpServletRequest request, String name) {
+		Cookie[] cookies = request.getCookies();
+		if (cookies != null && cookies.length > 0) {
+			for (Cookie cookie : cookies) {
+				if (cookie.getName().equals(name)) {
+					return Optional.of(cookie);
+				}
+			}
+		}
+		return Optional.empty();
 	}
 }

--- a/src/main/java/cinebox/domain/booking/service/BookingServiceImpl.java
+++ b/src/main/java/cinebox/domain/booking/service/BookingServiceImpl.java
@@ -18,6 +18,7 @@ import cinebox.common.exception.payment.NotFoundPaymentException;
 import cinebox.common.exception.payment.NotPaidBookingException;
 import cinebox.common.exception.screen.NotFoundScreenException;
 import cinebox.common.exception.user.NoAuthorizedUserException;
+import cinebox.common.utils.SecurityUtil;
 import cinebox.domain.booking.dto.BookingRequest;
 import cinebox.domain.booking.dto.BookingResponse;
 import cinebox.domain.booking.dto.TicketResponse;
@@ -33,7 +34,6 @@ import cinebox.domain.screen.repository.ScreenRepository;
 import cinebox.domain.seat.entity.Seat;
 import cinebox.domain.seat.repository.SeatRepository;
 import cinebox.domain.user.entity.User;
-import cinebox.security.SecurityUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 

--- a/src/main/java/cinebox/domain/like/service/MovieLikeServiceImpl.java
+++ b/src/main/java/cinebox/domain/like/service/MovieLikeServiceImpl.java
@@ -7,13 +7,13 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import cinebox.common.exception.movie.NotFoundMovieException;
+import cinebox.common.utils.SecurityUtil;
 import cinebox.domain.like.entity.MovieLike;
 import cinebox.domain.like.repository.MovieLikeRepository;
 import cinebox.domain.movie.dto.MovieResponse;
 import cinebox.domain.movie.entity.Movie;
 import cinebox.domain.movie.repository.MovieRepository;
 import cinebox.domain.user.entity.User;
-import cinebox.security.SecurityUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 

--- a/src/main/java/cinebox/domain/payment/service/PaymentServiceImpl.java
+++ b/src/main/java/cinebox/domain/payment/service/PaymentServiceImpl.java
@@ -14,6 +14,7 @@ import cinebox.common.exception.payment.InvalidPaymentStatusException;
 import cinebox.common.exception.payment.NotFoundPaymentException;
 import cinebox.common.exception.payment.NotPaidBookingException;
 import cinebox.common.exception.user.NoAuthorizedUserException;
+import cinebox.common.utils.SecurityUtil;
 import cinebox.domain.booking.entity.Booking;
 import cinebox.domain.booking.repository.BookingRepository;
 import cinebox.domain.payment.dto.PaymentRequest;
@@ -21,7 +22,6 @@ import cinebox.domain.payment.dto.PaymentResponse;
 import cinebox.domain.payment.entity.Payment;
 import cinebox.domain.payment.repository.PaymentRepository;
 import cinebox.domain.user.entity.User;
-import cinebox.security.SecurityUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 

--- a/src/main/java/cinebox/domain/review/service/ReviewServiceImpl.java
+++ b/src/main/java/cinebox/domain/review/service/ReviewServiceImpl.java
@@ -10,6 +10,7 @@ import cinebox.common.exception.movie.NotFoundMovieException;
 import cinebox.common.exception.review.NotFoundReviewException;
 import cinebox.common.exception.user.NoAuthorizedUserException;
 import cinebox.common.exception.user.NotFoundUserException;
+import cinebox.common.utils.SecurityUtil;
 import cinebox.domain.movie.entity.Movie;
 import cinebox.domain.movie.repository.MovieRepository;
 import cinebox.domain.review.dto.ReviewRequest;
@@ -18,7 +19,6 @@ import cinebox.domain.review.entity.Review;
 import cinebox.domain.review.repository.ReviewRepository;
 import cinebox.domain.user.entity.User;
 import cinebox.domain.user.repository.UserRepository;
-import cinebox.security.SecurityUtil;
 import lombok.RequiredArgsConstructor;
 
 @Service

--- a/src/main/java/cinebox/domain/user/controller/UserController.java
+++ b/src/main/java/cinebox/domain/user/controller/UserController.java
@@ -17,6 +17,8 @@ import org.springframework.web.bind.annotation.RestController;
 import cinebox.domain.user.dto.UserResponse;
 import cinebox.domain.user.dto.UserUpdateRequest;
 import cinebox.domain.user.service.UserService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -58,9 +60,12 @@ public class UserController {
 	}
 
 	// 사용자 회원 탈퇴
-	@DeleteMapping("/{userId}")
-	public ResponseEntity<Void> deleteUser(@PathVariable("userId") Long userId) {
-		userService.deleteUser(userId);
+	@PostMapping("/{userId}/withdraw")
+	public ResponseEntity<Void> withdrawUser(
+			@PathVariable("userId") Long userId,
+			HttpServletRequest request,
+			HttpServletResponse response) {
+		userService.withdrawUser(userId, request, response);
 		return ResponseEntity.noContent().build();
 	}
 

--- a/src/main/java/cinebox/domain/user/service/UserService.java
+++ b/src/main/java/cinebox/domain/user/service/UserService.java
@@ -4,6 +4,8 @@ import java.util.List;
 
 import cinebox.domain.user.dto.UserResponse;
 import cinebox.domain.user.dto.UserUpdateRequest;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 public interface UserService {
 
@@ -19,8 +21,8 @@ public interface UserService {
 	// 사용자 정보 수정
 	UserResponse updateUser(Long userId, UserUpdateRequest request);
 
-	// 사용자 삭제
-	void deleteUser(Long userId);
+	// 회원 탈퇴
+	void withdrawUser(Long userId, HttpServletRequest request, HttpServletResponse response);
 
 	// 사용자 복구
 	UserResponse restoreUser(Long userId);

--- a/src/main/java/cinebox/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/cinebox/domain/user/service/UserServiceImpl.java
@@ -9,11 +9,11 @@ import org.springframework.transaction.annotation.Transactional;
 
 import cinebox.common.exception.user.NoAuthorizedUserException;
 import cinebox.common.exception.user.NotFoundUserException;
+import cinebox.common.utils.SecurityUtil;
 import cinebox.domain.user.dto.UserResponse;
 import cinebox.domain.user.dto.UserUpdateRequest;
 import cinebox.domain.user.entity.User;
 import cinebox.domain.user.repository.UserRepository;
-import cinebox.security.SecurityUtil;
 import lombok.RequiredArgsConstructor;
 
 @Service

--- a/src/main/java/cinebox/security/config/RedisRepositoryConfig.java
+++ b/src/main/java/cinebox/security/config/RedisRepositoryConfig.java
@@ -3,6 +3,7 @@ package cinebox.security.config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
@@ -11,6 +12,7 @@ import org.springframework.data.redis.core.RedisKeyValueTemplate;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.mapping.RedisMappingContext;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 import cinebox.domain.auth.entity.TokenRedis;
 
@@ -36,4 +38,15 @@ public class RedisRepositoryConfig {
 		redisTemplate.afterPropertiesSet();
 		return new RedisKeyValueTemplate(new RedisKeyValueAdapter(redisTemplate), new RedisMappingContext());
 	}
+
+    @Bean
+    @Primary
+    public RedisTemplate<String, String> redisStringTemplate(RedisConnectionFactory redisConnectionFactory) {
+    	RedisTemplate<String, String> template = new RedisTemplate<>();
+    	template.setConnectionFactory(redisConnectionFactory);
+		template.setKeySerializer(new StringRedisSerializer());
+		template.setValueSerializer(new StringRedisSerializer());
+		template.afterPropertiesSet();
+		return template;
+    }
 }

--- a/src/main/java/cinebox/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/cinebox/security/jwt/JwtAuthenticationFilter.java
@@ -7,6 +7,7 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
 
+import cinebox.common.utils.CookieUtil;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.Cookie;
@@ -18,41 +19,29 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
-    private final JwtTokenProvider jwtTokenProvider;
+	private final JwtTokenProvider jwtTokenProvider;
 
-    @Override
-    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
-            throws ServletException, IOException {
-        log.debug("## doFilterInternal 동작...");
-        // 쿠키에서 액세스 토큰과 리프레시 토큰 추출
-        Optional<Cookie> accessTokenCookie = getCookie(request, "AT");
-        Optional<Cookie> refreshTokenCookie = getCookie(request, "RT");
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+			throws ServletException, IOException {
+		log.debug("## doFilterInternal 동작...");
+		// 쿠키에서 액세스 토큰과 리프레시 토큰 추출
+		Optional<Cookie> accessTokenCookie = CookieUtil.getCookie(request, "AT");
+		Optional<Cookie> refreshTokenCookie = CookieUtil.getCookie(request, "RT");
 
-        UsernamePasswordAuthenticationToken authentication = null;
+		UsernamePasswordAuthenticationToken authentication = null;
 
-        if (accessTokenCookie.isPresent() && jwtTokenProvider.validateToken(accessTokenCookie.get().getValue())) {
-            // 유효한 액세스 토큰이 있는 경우
-            authentication = jwtTokenProvider.createAuthenticationFromToken(accessTokenCookie.get().getValue());
-        } else if (refreshTokenCookie.isPresent() && jwtTokenProvider.validateToken(refreshTokenCookie.get().getValue())) {
-            // 액세스 토큰이 없거나 만료되었을 때, 리프레시 토큰으로 재발급 시도
-            authentication = jwtTokenProvider.replaceAccessToken(response, refreshTokenCookie.get().getValue());
-        }
+		if (accessTokenCookie.isPresent() && jwtTokenProvider.validateToken(accessTokenCookie.get().getValue())) {
+			// 유효한 액세스 토큰이 있는 경우
+			authentication = jwtTokenProvider.createAuthenticationFromToken(accessTokenCookie.get().getValue());
+		} else if (refreshTokenCookie.isPresent() && jwtTokenProvider.validateToken(refreshTokenCookie.get().getValue())) {
+			// 액세스 토큰이 없거나 만료되었을 때, 리프레시 토큰으로 재발급 시도
+			authentication = jwtTokenProvider.replaceAccessToken(response, refreshTokenCookie.get().getValue());
+		}
 
-        if (authentication != null) {
-            SecurityContextHolder.getContext().setAuthentication(authentication);
-        }
-        chain.doFilter(request, response);
-    }
-    
-    private Optional<Cookie> getCookie(HttpServletRequest request, String name) {
-        Cookie[] cookies = request.getCookies();
-        if (cookies != null && cookies.length > 0) {
-            for (Cookie cookie : cookies) {
-                if (cookie.getName().equals(name)) {
-                    return Optional.of(cookie);
-                }
-            }
-        }
-		return Optional.empty();
+		if (authentication != null) {
+			SecurityContextHolder.getContext().setAuthentication(authentication);
+		}
+		chain.doFilter(request, response);
 	}
 }

--- a/src/main/java/cinebox/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/cinebox/security/jwt/JwtTokenProvider.java
@@ -188,4 +188,9 @@ public class JwtTokenProvider {
 			log.error("액세스 토큰 블랙리스트 등록 실패", e);
 		}
 	}
+	
+	public boolean isTokenBlacklisted(String token) {
+		String blacklistKey = "blacklist:" + token;
+		return redisStringTemplate.hasKey(blacklistKey);
+	}
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

#80 

## 📝작업 내용

- 로그아웃 (logout)
   - 쿠키에 AccessToken이 있다면 해당 Access Token에 대한 블랙리스트 등록
   - 클라이언트에게 만료시간이 0인 쿠키를 주어 쿠키 삭제
- 회원탈퇴 (withdraw)
   - 쿠키에 AccessToken이 있다면 해당 Access Token에 대한 블랙리스트 등록
   - 클라이언트에게 만료시간이 0인 쿠키를 주어 쿠키 삭제
   - 해당 사용자에 대한 Refresh Token을 Redis에서 삭제

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
