### PR TITLE
Feat(#82): 나이에 따른 관람 제한 구현

### DIFF
--- a/src/main/java/cinebox/batch/service/MovieBatchService.java
+++ b/src/main/java/cinebox/batch/service/MovieBatchService.java
@@ -20,6 +20,7 @@ import cinebox.batch.dto.KmdbResponse;
 import cinebox.batch.dto.KobisMovieListResponse;
 import cinebox.batch.dto.KobisMovieListResponse.KobisMovieDto;
 import cinebox.common.enums.MovieStatus;
+import cinebox.common.enums.RatingGrade;
 import cinebox.domain.movie.entity.Movie;
 import cinebox.domain.movie.repository.MovieRepository;
 import lombok.RequiredArgsConstructor;
@@ -185,7 +186,7 @@ public class MovieBatchService {
 			.posterImageUrl(posterImageUrl)
 			.releaseDate(releaseDate)
 			.runTime(runtime)
-			.ratingGrade(rating)
+			.ratingGrade(RatingGrade.fromLabel(rating))
 			.status(MovieStatus.UNRELEASED)
 			.build();
 	}

--- a/src/main/java/cinebox/common/enums/RatingGrade.java
+++ b/src/main/java/cinebox/common/enums/RatingGrade.java
@@ -1,0 +1,32 @@
+package cinebox.common.enums;
+
+import cinebox.common.exception.movie.InvalidRatingException;
+import lombok.Getter;
+
+@Getter
+public enum RatingGrade {
+	ALL("전체관람가"),
+	AGE_12("12세관람가"),
+	AGE_15("15세관람가"),
+	AGE_18("청소년관람불가"),
+	NOT_SET("등급미설정");
+
+	private final String label;
+
+	RatingGrade(String label) {
+		this.label = label;
+	}
+
+	public static RatingGrade fromLabel(String label) {
+		if (label == null) {
+			return NOT_SET;
+		}
+		for (RatingGrade rating : values()) {
+			if(rating.getLabel().equals(label)) {
+				return rating;
+			}
+		}
+		
+		throw InvalidRatingException.EXCEPTION;
+	}
+}

--- a/src/main/java/cinebox/common/enums/RatingGrade.java
+++ b/src/main/java/cinebox/common/enums/RatingGrade.java
@@ -5,16 +5,18 @@ import lombok.Getter;
 
 @Getter
 public enum RatingGrade {
-	ALL("전체관람가"),
-	AGE_12("12세관람가"),
-	AGE_15("15세관람가"),
-	AGE_18("청소년관람불가"),
-	NOT_SET("등급미설정");
+	ALL("전체관람가", 0),
+	AGE_12("12세관람가", 12),
+	AGE_15("15세관람가", 15),
+	AGE_18("청소년관람불가", 18),
+	NOT_SET("등급미설정", 0);
 
 	private final String label;
+	private final int minAge;
 
-	RatingGrade(String label) {
+	RatingGrade(String label, int minAge) {
 		this.label = label;
+		this.minAge = minAge;
 	}
 
 	public static RatingGrade fromLabel(String label) {

--- a/src/main/java/cinebox/common/exception/ExceptionMessage.java
+++ b/src/main/java/cinebox/common/exception/ExceptionMessage.java
@@ -53,6 +53,8 @@ public enum ExceptionMessage {
 	SCREEN_NOT_FOUND("상영 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND, "Not Found Screen for Booking"),
 	NOT_FOUND_BOOKING("예매된 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND, "Not Found booking information"),
 	ALREADY_REFUNDED("이미 환불된 예매입니다.", HttpStatus.BAD_REQUEST, "Already Refunded"),
+	INSUFFICIENT_AGE("관람이 불가한 영화입니다.", HttpStatus.FORBIDDEN, "Insufficient Age"),
+	AGE_VERIFICATION_FAILED("나이를 확인할 수 없습니다.", HttpStatus.BAD_REQUEST, "Age Verification Failed"),
 	
 	//payment
 	SEAT_ALREADY_PAYMENT("이미 결제가 완료되었습니다", HttpStatus.BAD_REQUEST,"Payment has already been completed"),

--- a/src/main/java/cinebox/common/exception/ExceptionMessage.java
+++ b/src/main/java/cinebox/common/exception/ExceptionMessage.java
@@ -26,6 +26,7 @@ public enum ExceptionMessage {
 	NOT_FOUND_MOVIE("유효하지 않은 MovieId 입니다.", HttpStatus.NOT_FOUND, "Not Found MovieId"),
 	DUPLICATED_MOVIE("이미 존재하는 영화입니다.", HttpStatus.CONFLICT, "Conflict Title and ReleaseDate"),
 	MOVIE_DELETE_FAILED("영화 삭제에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR, "Failed to Delete Movie"),
+	INVALID_RATING("유효하지 않은 관람등급입니다.", HttpStatus.BAD_REQUEST, "Invalid Rating Grade"),
 	
 	// s3
 	S3_SERVER_ERROR("S3 서버 에러 발생", HttpStatus.INTERNAL_SERVER_ERROR, "S3 Server Error"),

--- a/src/main/java/cinebox/common/exception/booking/AgeVerificationException.java
+++ b/src/main/java/cinebox/common/exception/booking/AgeVerificationException.java
@@ -1,0 +1,12 @@
+package cinebox.common.exception.booking;
+
+import cinebox.common.exception.BaseException;
+import cinebox.common.exception.ExceptionMessage;
+
+public class AgeVerificationException extends BaseException {
+	public static final BaseException EXCEPTION = new AgeVerificationException();
+
+	private AgeVerificationException() {
+		super(ExceptionMessage.AGE_VERIFICATION_FAILED);
+	}
+}

--- a/src/main/java/cinebox/common/exception/booking/AlreadyBookedSeatsException.java
+++ b/src/main/java/cinebox/common/exception/booking/AlreadyBookedSeatsException.java
@@ -4,11 +4,10 @@ import cinebox.common.exception.BaseException;
 import cinebox.common.exception.ExceptionMessage;
 
 public class AlreadyBookedSeatsException extends BaseException {
-	 public static final BaseException EXCEPTION = new AlreadyBookedSeatsException();
-	 
-    private AlreadyBookedSeatsException() {
-    	 super(ExceptionMessage.SEAT_ALREADY_BOOKED);
-    }
-    
-  
+	public static final BaseException EXCEPTION = new AlreadyBookedSeatsException();
+
+	private AlreadyBookedSeatsException() {
+		super(ExceptionMessage.SEAT_ALREADY_BOOKED);
+	}
+
 }

--- a/src/main/java/cinebox/common/exception/booking/InsufficientAgeException.java
+++ b/src/main/java/cinebox/common/exception/booking/InsufficientAgeException.java
@@ -1,0 +1,12 @@
+package cinebox.common.exception.booking;
+
+import cinebox.common.exception.BaseException;
+import cinebox.common.exception.ExceptionMessage;
+
+public class InsufficientAgeException extends BaseException {
+	public static final BaseException EXCEPTION = new InsufficientAgeException();
+
+	private InsufficientAgeException() {
+		super(ExceptionMessage.INSUFFICIENT_AGE);
+	}
+}

--- a/src/main/java/cinebox/common/exception/movie/InvalidRatingException.java
+++ b/src/main/java/cinebox/common/exception/movie/InvalidRatingException.java
@@ -1,0 +1,12 @@
+package cinebox.common.exception.movie;
+
+import cinebox.common.exception.BaseException;
+import cinebox.common.exception.ExceptionMessage;
+
+public class InvalidRatingException extends BaseException {
+	public static final BaseException EXCEPTION = new InvalidRatingException();
+
+	private InvalidRatingException() {
+		super(ExceptionMessage.INVALID_RATING);
+	}
+}

--- a/src/main/java/cinebox/common/runner/UserInitializer.java
+++ b/src/main/java/cinebox/common/runner/UserInitializer.java
@@ -1,0 +1,42 @@
+package cinebox.common.runner;
+
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+import cinebox.common.enums.Role;
+import cinebox.domain.user.entity.User;
+import cinebox.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class UserInitializer implements CommandLineRunner {
+	private final UserRepository userRepository;
+	private final PasswordEncoder passwordEncoder;
+
+	@Override
+	public void run(String... args) throws Exception {
+		String adminIdentifier = "admin";
+
+		// 기존에 admin 계정이 있는지 확인
+		boolean adminExists = userRepository.existsByIdentifier(adminIdentifier);
+
+		if (!adminExists) {
+			// admin 계정 생성
+			User adminUser = User.builder()
+					.identifier(adminIdentifier)
+					.password(passwordEncoder.encode("admin123"))
+					.email("admin@cinebox.com")
+					.name("관리자")
+					.phone("010-1234-5678")
+					.role(Role.ADMIN)
+					.build();
+
+			userRepository.save(adminUser);
+			log.info("관리자 계정이 생성되었습니다.");
+		}
+	}
+}

--- a/src/main/java/cinebox/domain/booking/dto/BookingRequest.java
+++ b/src/main/java/cinebox/domain/booking/dto/BookingRequest.java
@@ -2,16 +2,9 @@ package cinebox.domain.booking.dto;
 
 import java.util.List;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
-@Getter
-@AllArgsConstructor
-@NoArgsConstructor
-public class BookingRequest {
-
-	private Long screenId;
-	private List<String> seatNumbers; // 좌석번호 (예: ["A1", "A2", "B1"]
-
+public record BookingRequest(
+		Long screenId,
+		List<String> seatNumbers
+) {
+	
 }

--- a/src/main/java/cinebox/domain/booking/service/BookingServiceImpl.java
+++ b/src/main/java/cinebox/domain/booking/service/BookingServiceImpl.java
@@ -75,7 +75,7 @@ public class BookingServiceImpl implements BookingService {
 			throw AgeVerificationException.EXCEPTION;
 		}
 
-		Screen screen = screenRepository.findById(request.getScreenId())
+		Screen screen = screenRepository.findById(request.screenId())
 				.orElseThrow(() -> NotFoundScreenException.EXCEPTION);
 		
 		Movie movie = screen.getMovie();
@@ -84,17 +84,17 @@ public class BookingServiceImpl implements BookingService {
 			throw InsufficientAgeException.EXCEPTION;
 		}
 
-		int alreadyBookedCount = bookingSeatRepository.countByScreen_ScreenIdAndSeat_SeatNumberIn(request.getScreenId(), request.getSeatNumbers());
+		int alreadyBookedCount = bookingSeatRepository.countByScreen_ScreenIdAndSeat_SeatNumberIn(request.screenId(), request.seatNumbers());
 		if (alreadyBookedCount > 0) {
 			throw AlreadyBookedSeatsException.EXCEPTION;
 		}
 
-		BigDecimal totalPrice = screen.getPrice().multiply(BigDecimal.valueOf(request.getSeatNumbers().size()));
+		BigDecimal totalPrice = screen.getPrice().multiply(BigDecimal.valueOf(request.seatNumbers().size()));
 
 		Booking booking = Booking.createBooking(currentUser, totalPrice);
 		Booking savedBooking = bookingRepository.save(booking);
 
-		List<BookingSeat> bookingSeats = request.getSeatNumbers().stream()
+		List<BookingSeat> bookingSeats = request.seatNumbers().stream()
 				.map(seatNumber -> {
 					Seat seat = seatRepository
 							.findBySeatNumberAndAuditorium_AuditoriumId(seatNumber, screen.getAuditorium().getAuditoriumId())

--- a/src/main/java/cinebox/domain/movie/dto/MovieResponse.java
+++ b/src/main/java/cinebox/domain/movie/dto/MovieResponse.java
@@ -32,7 +32,7 @@ public record MovieResponse (
     			movie.getGenre(),
     			movie.getReleaseDate(),
     			movie.getRunTime(),
-    			movie.getRatingGrade(),
+    			movie.getRatingGrade().getLabel(),
     			movie.getStatus(),
     			movie.getLikeCount());
     }

--- a/src/main/java/cinebox/domain/movie/entity/Movie.java
+++ b/src/main/java/cinebox/domain/movie/entity/Movie.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import cinebox.common.entity.BaseTimeEntity;
 import cinebox.common.enums.MovieStatus;
+import cinebox.common.enums.RatingGrade;
 import cinebox.domain.like.entity.MovieLike;
 import cinebox.domain.movie.dto.MovieRequest;
 import cinebox.domain.review.entity.Review;
@@ -59,7 +60,8 @@ public class Movie extends BaseTimeEntity {
 	private Integer runTime;
 
 	@Column(name = "rating_grade")
-	private String ratingGrade;
+	@Enumerated(EnumType.STRING)
+	private RatingGrade ratingGrade;
 
 	@Column(nullable = false)
 	@Enumerated(EnumType.STRING)
@@ -87,7 +89,7 @@ public class Movie extends BaseTimeEntity {
 				.posterImageUrl(posterImageUrl)
 				.releaseDate(request.releaseDate())
 				.runTime(request.runtime())
-				.ratingGrade(request.ratingGrade())
+				.ratingGrade(RatingGrade.fromLabel(request.ratingGrade()))
 				.status(request.status() != null ? request.status() : MovieStatus.UNRELEASED)
 				.likeCount(0)
 				.build();
@@ -102,7 +104,7 @@ public class Movie extends BaseTimeEntity {
 		this.posterImageUrl = newPosterImageUrl != null ? newPosterImageUrl : this.posterImageUrl;
 		this.releaseDate = request.releaseDate() != null ? request.releaseDate() : this.releaseDate;
 		this.runTime = request.runtime() != null ? request.runtime() : this.runTime;
-		this.ratingGrade = request.ratingGrade() != null ? request.ratingGrade() : this.ratingGrade;
+		this.ratingGrade = request.ratingGrade() != null ? RatingGrade.fromLabel(request.ratingGrade()) : this.ratingGrade;
 		this.status = request.status() != null ? request.status() : this.status;
 	}
 	


### PR DESCRIPTION
## #️⃣연관된 이슈

#82 

## 📝작업 내용

- 관람 등급 enum으로 변경
- 관람 등급의 나이에 맞지 않은 경우 예매가 제한되도록 구현
- 타입 변경으로 인해 db 초기화가 이뤄질 수 있어. admin 계정 초기화 구현

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
