### PR TITLE
Feat(#91): 대기 상태의 예매 취소 기능 구현

### DIFF
--- a/src/main/java/cinebox/batch/service/BookingBatchService.java
+++ b/src/main/java/cinebox/batch/service/BookingBatchService.java
@@ -42,8 +42,7 @@ public class BookingBatchService {
 					.orElseThrow(() -> NotFoundPaymentException.EXCEPTION);
 			payment.updateStatus(PaymentStatus.FAILED);
 		}
-		
-		bookingRepository.deleteAll(expiredBookings);
+
 		log.info("Canceled {} expired pending bookings", expiredBookings.size());
 	}
 }

--- a/src/main/java/cinebox/common/exception/ExceptionMessage.java
+++ b/src/main/java/cinebox/common/exception/ExceptionMessage.java
@@ -55,7 +55,8 @@ public enum ExceptionMessage {
 	ALREADY_REFUNDED("이미 환불된 예매입니다.", HttpStatus.BAD_REQUEST, "Already Refunded"),
 	INSUFFICIENT_AGE("관람이 불가한 영화입니다.", HttpStatus.FORBIDDEN, "Insufficient Age"),
 	AGE_VERIFICATION_FAILED("나이를 확인할 수 없습니다.", HttpStatus.BAD_REQUEST, "Age Verification Failed"),
-	
+	INSUFFICIENT_BOOKING_STATUS("예매 상태를 확인해주세요.", HttpStatus.BAD_REQUEST, "Insufficient Booking Status"),
+
 	//payment
 	SEAT_ALREADY_PAYMENT("이미 결제가 완료되었습니다", HttpStatus.BAD_REQUEST,"Payment has already been completed"),
 	NOT_FOUND_PAYMENT("결제정보를 찾지못했습니다.", HttpStatus.NOT_FOUND, "Not Found Payment information"),

--- a/src/main/java/cinebox/common/exception/booking/InsufficientBookingStatusException.java
+++ b/src/main/java/cinebox/common/exception/booking/InsufficientBookingStatusException.java
@@ -1,0 +1,12 @@
+package cinebox.common.exception.booking;
+
+import cinebox.common.exception.BaseException;
+import cinebox.common.exception.ExceptionMessage;
+
+public class InsufficientBookingStatusException extends BaseException {
+	public static final BaseException EXCEPTION = new InsufficientBookingStatusException();
+
+	private InsufficientBookingStatusException() {
+		super(ExceptionMessage.INSUFFICIENT_BOOKING_STATUS);
+	}
+}

--- a/src/main/java/cinebox/domain/booking/controller/BookingController.java
+++ b/src/main/java/cinebox/domain/booking/controller/BookingController.java
@@ -53,4 +53,11 @@ public class BookingController {
 		PaymentResponse paymentResponse = bookingService.refundPayment(bookingId);
 		return ResponseEntity.ok(paymentResponse);
 	}
+
+	// 예매 대기 취소
+	@PostMapping("/{bookingId}/cancel")
+	public ResponseEntity<Void> cancelBooking(@PathVariable("bookingId") Long bookingId) {
+		bookingService.cancelBooking(bookingId);
+		return ResponseEntity.noContent().build();
+	}
 }

--- a/src/main/java/cinebox/domain/booking/service/BookingService.java
+++ b/src/main/java/cinebox/domain/booking/service/BookingService.java
@@ -19,4 +19,7 @@ public interface BookingService {
 
 	// 예매 취소 및 환불
 	PaymentResponse refundPayment(Long bookingId);
+
+	// 예매 대기 취소
+	void cancelBooking(Long bookingId);
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

#91 

## 📝작업 내용

- 배치 서비스에서 예매 기록 자체를 삭제하던 것 수정 -> 예매 기록이 남아있도록
- 결제되지 않은 예매 대기 상태의 예매를 Cancel 상태로 변경

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
