### PR TITLE
Feat(#71): Read/Write DB 분리

### DIFF
--- a/src/main/java/cinebox/common/datasource/DataSourceConfiguration.java
+++ b/src/main/java/cinebox/common/datasource/DataSourceConfiguration.java
@@ -1,0 +1,61 @@
+package cinebox.common.datasource;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.sql.DataSource;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.DependsOn;
+import org.springframework.context.annotation.Primary;
+import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
+
+import com.zaxxer.hikari.HikariDataSource;
+
+@Configuration
+public class DataSourceConfiguration {
+
+	public static final String PRIMARY_DATASOURCE = "primaryDataSource";
+	public static final String SECONDARY_DATASOURCE = "secondaryDataSource";
+
+	@Bean(PRIMARY_DATASOURCE)
+	@ConfigurationProperties(prefix = "spring.datasource.primary.hikari")
+	public DataSource primaryDataSource() {
+		return DataSourceBuilder.create().type(HikariDataSource.class).build();
+	}
+
+	@Bean(SECONDARY_DATASOURCE)
+	@ConfigurationProperties(prefix = "spring.datasource.secondary.hikari")
+	public DataSource secondaryDataSource() {
+		return DataSourceBuilder.create().type(HikariDataSource.class).build();
+	}
+
+	@Bean
+	@Primary
+	@DependsOn({ PRIMARY_DATASOURCE, SECONDARY_DATASOURCE })
+	public DataSource routingDataSource(@Qualifier(PRIMARY_DATASOURCE) DataSource primaryDataSource,
+			@Qualifier(SECONDARY_DATASOURCE) DataSource secondaryDataSource) {
+
+		RoutingDataSource routingDataSource = new RoutingDataSource();
+		Map<Object, Object> dataSourceMap = new HashMap<>();
+
+		dataSourceMap.put("primary", primaryDataSource);
+		dataSourceMap.put("secondary", secondaryDataSource);
+
+		routingDataSource.setTargetDataSources(dataSourceMap);
+		routingDataSource.setDefaultTargetDataSource(primaryDataSource);
+
+		return routingDataSource;
+	}
+
+	@Bean
+	@DependsOn("routingDataSource")
+	public LazyConnectionDataSourceProxy dataSource(DataSource routingDataSource) {
+		return new LazyConnectionDataSourceProxy(routingDataSource);
+	}
+
+}

--- a/src/main/java/cinebox/common/datasource/RoutingDataSource.java
+++ b/src/main/java/cinebox/common/datasource/RoutingDataSource.java
@@ -1,0 +1,14 @@
+package cinebox.common.datasource;
+
+import org.springframework.jdbc.datasource.lookup.AbstractRoutingDataSource;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+public class RoutingDataSource extends AbstractRoutingDataSource {
+
+    @Override
+    protected Object determineCurrentLookupKey() {
+        return TransactionSynchronizationManager.isCurrentTransactionReadOnly()
+                ? "secondary"
+				: "primary";
+	}
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

#71 

## 📝작업 내용

- Primary, Secondary DB에 대한 연결 설정
- Transactional 어노테이션을 통해 readOnly = true이 있다면 Secondary(Reader) DB에서 조회, 없다면 Primary에서 읽기/쓰기가 진행됨

### application.properties
```
# Primary DataSource
spring.datasource.primary.hikari.type=com.zaxxer.hikari.HikariDataSource
spring.datasource.primary.hikari.driver-class-name=com.mysql.cj.jdbc.Driver
spring.datasource.primary.hikari.username=<username>
spring.datasource.primary.hikari.password=<password>
spring.datasource.primary.hikari.jdbc-url=jdbc:mysql://<primary-database-url>:3306/<database>

# Secondary DataSource
spring.datasource.secondary.hikari.type=com.zaxxer.hikari.HikariDataSource
spring.datasource.secondary.hikari.driver-class-name=com.mysql.cj.jdbc.Driver
spring.datasource.secondary.hikari.username=<username>
spring.datasource.secondary.hikari.password=<password>
spring.datasource.secondary.hikari.jdbc-url=jdbc:mysql://<secondary-database-url>:3306/<database>

# 공통 Hikari 설정
spring.datasource.hikari.pool-name=Hikari
spring.datasource.hikari.auto-commit=false
```

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
