### PR TITLE
Feat(#31): 소셜 로그인 구현

### DIFF
--- a/src/main/java/cinebox/common/enums/PlatformType.java
+++ b/src/main/java/cinebox/common/enums/PlatformType.java
@@ -1,0 +1,6 @@
+package cinebox.common.enums;
+
+public enum PlatformType {
+	LOCAL,
+	KAKAO
+}

--- a/src/main/java/cinebox/common/exception/ExceptionMessage.java
+++ b/src/main/java/cinebox/common/exception/ExceptionMessage.java
@@ -12,6 +12,7 @@ public enum ExceptionMessage {
 	NOT_FOUND_TOKEN("토큰을 조회할 수 없습니다. 다시 로그인 해 주세요.", HttpStatus.UNAUTHORIZED, "Not Found Token"),
 	INVALID_TOKEN("유효하지 않은 토큰입니다. 다시 로그인 해 주세요.", HttpStatus.UNAUTHORIZED, "Invaled Token"),
 	REDIS_SERVER_ERROR("Redis 서버 에러 발생", HttpStatus.INTERNAL_SERVER_ERROR, "Redis Server Error"),
+	TOKEN_PARSING_ERROR("OAuth 토큰 파싱에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR, "Token Parsing Error"),
 	
 	// user
 	NOT_FOUND_USER("유효하지 않은 UserId 입니다.", HttpStatus.NOT_FOUND, "Not Found UserId"),

--- a/src/main/java/cinebox/common/exception/auth/TokenParsingException.java
+++ b/src/main/java/cinebox/common/exception/auth/TokenParsingException.java
@@ -1,0 +1,13 @@
+package cinebox.common.exception.auth;
+
+import cinebox.common.exception.BaseException;
+import cinebox.common.exception.ExceptionMessage;
+
+public class TokenParsingException extends BaseException {
+	public static final BaseException EXCEPTION = new TokenParsingException();
+
+	private TokenParsingException() {
+		super(ExceptionMessage.TOKEN_PARSING_ERROR);
+
+	}
+}

--- a/src/main/java/cinebox/common/runner/UserInitializer.java
+++ b/src/main/java/cinebox/common/runner/UserInitializer.java
@@ -1,9 +1,12 @@
 package cinebox.common.runner;
 
+import java.time.LocalDate;
+
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
 
+import cinebox.common.enums.PlatformType;
 import cinebox.common.enums.Role;
 import cinebox.domain.user.entity.User;
 import cinebox.domain.user.repository.UserRepository;
@@ -33,6 +36,8 @@ public class UserInitializer implements CommandLineRunner {
 					.name("관리자")
 					.phone("010-1234-5678")
 					.role(Role.ADMIN)
+					.birthDate(LocalDate.parse("1900-01-01"))
+					.platformType(PlatformType.LOCAL)
 					.build();
 
 			userRepository.save(adminUser);

--- a/src/main/java/cinebox/common/utils/KakaoUtil.java
+++ b/src/main/java/cinebox/common/utils/KakaoUtil.java
@@ -1,0 +1,91 @@
+package cinebox.common.utils;
+
+import java.util.Arrays;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import cinebox.common.exception.auth.TokenParsingException;
+import cinebox.domain.auth.dto.KakaoProfile;
+import cinebox.domain.auth.dto.OAuthToken;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@Slf4j
+public class KakaoUtil {
+
+	@Value("${spring.kakao.auth.client}")
+	private String client;
+
+	@Value("${spring.kakao.auth.redirect}")
+	private String redirect;
+
+	public OAuthToken requestToken(String accessCode) {
+		RestTemplate restTemplate = new RestTemplate();
+		HttpHeaders headers = new HttpHeaders();
+		headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+
+		MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+		params.add("grant_type", "authorization_code");
+		params.add("client_id", client);
+		params.add("redirect_uri", redirect);
+		params.add("code", accessCode);
+		
+		HttpEntity<MultiValueMap<String, String>> kakaoTokenRequest = new HttpEntity<>(params, headers);
+
+		ResponseEntity<String> response = restTemplate.exchange(
+				"https://kauth.kakao.com/oauth/token",
+				HttpMethod.POST,
+				kakaoTokenRequest,
+				String.class);
+
+		ObjectMapper objectMapper = new ObjectMapper();
+		OAuthToken oAuthToken = null;
+		try {
+			oAuthToken = objectMapper.readValue(response.getBody(), OAuthToken.class);
+			log.info("oAuthToken : " + oAuthToken.access_token());
+		} catch (JsonProcessingException e) {
+			throw TokenParsingException.EXCEPTION;
+		}
+		return oAuthToken;
+	}
+	
+	public KakaoProfile requestProfile(OAuthToken oAuthToken) {
+		RestTemplate restTemplate2 = new RestTemplate();
+        HttpHeaders headers2 = new HttpHeaders();
+
+        headers2.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+        headers2.add("Authorization","Bearer "+ oAuthToken.access_token());
+
+        HttpEntity<MultiValueMap<String,String>> kakaoProfileRequest = new HttpEntity <>(headers2);
+
+        ResponseEntity<String> response2 = restTemplate2.exchange(
+                "https://kapi.kakao.com/v2/user/me",
+                HttpMethod.GET,
+                kakaoProfileRequest,
+                String.class);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        KakaoProfile kakaoProfile = null;
+
+        try {
+            kakaoProfile = objectMapper.readValue(response2.getBody(), KakaoProfile.class);
+        } catch (JsonProcessingException e) {
+            log.info(Arrays.toString(e.getStackTrace()));
+            throw TokenParsingException.EXCEPTION;
+        }
+
+        return kakaoProfile;
+	}
+}

--- a/src/main/java/cinebox/domain/auth/controller/AuthController.java
+++ b/src/main/java/cinebox/domain/auth/controller/AuthController.java
@@ -66,4 +66,9 @@ public class AuthController {
 		}
 		return ResponseEntity.ok(response);
 	}
+	
+	@GetMapping("/callback/test")
+	public ResponseEntity<?> test() {
+		return ResponseEntity.ok().build();
+	}
 }

--- a/src/main/java/cinebox/domain/auth/controller/AuthController.java
+++ b/src/main/java/cinebox/domain/auth/controller/AuthController.java
@@ -1,5 +1,6 @@
 package cinebox.domain.auth.controller;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -11,6 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import cinebox.domain.auth.dto.AuthRequest;
 import cinebox.domain.auth.dto.AuthResponse;
+import cinebox.domain.auth.dto.KakaoProfile;
 import cinebox.domain.auth.dto.SignUpRequest;
 import cinebox.domain.auth.service.AuthService;
 import cinebox.domain.user.dto.UserResponse;
@@ -45,10 +47,14 @@ public class AuthController {
 	}
 	
 	@GetMapping("/callback")
-	public ResponseEntity<AuthResponse> kakaoLogin(
+	public ResponseEntity<?> kakaoLogin(
 			@RequestParam("code") String accessCode,
 			HttpServletResponse httpServletResponse) {
-		AuthResponse response = authService.oAuthLogin(accessCode, httpServletResponse);
+		Object response = authService.oAuthLogin(accessCode, httpServletResponse);
+		
+		if (response instanceof KakaoProfile) {
+			return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(response);
+		}
 		return ResponseEntity.ok(response);
 	}
 }

--- a/src/main/java/cinebox/domain/auth/controller/AuthController.java
+++ b/src/main/java/cinebox/domain/auth/controller/AuthController.java
@@ -66,9 +66,4 @@ public class AuthController {
 		}
 		return ResponseEntity.ok(response);
 	}
-	
-	@GetMapping("/callback/test")
-	public ResponseEntity<?> test() {
-		return ResponseEntity.ok().build();
-	}
 }

--- a/src/main/java/cinebox/domain/auth/controller/AuthController.java
+++ b/src/main/java/cinebox/domain/auth/controller/AuthController.java
@@ -2,9 +2,11 @@ package cinebox.domain.auth.controller;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import cinebox.domain.auth.dto.AuthRequest;
@@ -40,5 +42,13 @@ public class AuthController {
 	public ResponseEntity<Void> logout(HttpServletRequest request, HttpServletResponse response) {
 		authService.logout(request, response);
 		return ResponseEntity.noContent().build();
+	}
+	
+	@GetMapping("/callback")
+	public ResponseEntity<AuthResponse> kakaoLogin(
+			@RequestParam("code") String accessCode,
+			HttpServletResponse httpServletResponse) {
+		AuthResponse response = authService.oAuthLogin(accessCode, httpServletResponse);
+		return ResponseEntity.ok(response);
 	}
 }

--- a/src/main/java/cinebox/domain/auth/controller/AuthController.java
+++ b/src/main/java/cinebox/domain/auth/controller/AuthController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import cinebox.common.validation.CreateGroup;
 import cinebox.domain.auth.dto.AuthRequest;
 import cinebox.domain.auth.dto.AuthResponse;
 import cinebox.domain.auth.dto.KakaoProfile;
@@ -26,10 +27,18 @@ import lombok.RequiredArgsConstructor;
 public class AuthController {
 	private final AuthService authService;
 
+	// 회원가입
 	@PostMapping("/signup")
-	public ResponseEntity<UserResponse> signup(@RequestBody @Validated SignUpRequest user) {
-		UserResponse newUser = authService.signup(user);
-		return ResponseEntity.ok().body(newUser);
+	public ResponseEntity<UserResponse> signup(@RequestBody @Validated SignUpRequest request) {
+		UserResponse response = authService.signup(request);
+		return ResponseEntity.ok(response);
+	}
+
+	// 카카오 회원가입
+	@PostMapping("/signup/kakao")
+	public ResponseEntity<UserResponse> kakaoSignup(@RequestBody @Validated(CreateGroup.class) SignUpRequest request) {
+		UserResponse response = authService.kakaoSignup(request);
+		return ResponseEntity.ok(response);
 	}
 
 	@PostMapping("/login")

--- a/src/main/java/cinebox/domain/auth/dto/AuthRequest.java
+++ b/src/main/java/cinebox/domain/auth/dto/AuthRequest.java
@@ -1,15 +1,8 @@
 package cinebox.domain.auth.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
-
-@Getter
-@Setter
-@AllArgsConstructor
-@NoArgsConstructor
-public class AuthRequest {
-    private String identifier;
-    private String password;
+public record AuthRequest(
+		String identifier,
+		String password
+) {
+	
 }

--- a/src/main/java/cinebox/domain/auth/dto/AuthResponse.java
+++ b/src/main/java/cinebox/domain/auth/dto/AuthResponse.java
@@ -1,14 +1,9 @@
 package cinebox.domain.auth.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.Setter;
-
-@Getter
-@Setter
-@AllArgsConstructor
-public class AuthResponse {
-	private Long userId;
-	private String role;
-	private String identifier;
+public record AuthResponse(
+		Long userId,
+		String role,
+		String idnetifier
+) {
+	
 }

--- a/src/main/java/cinebox/domain/auth/dto/KakaoProfile.java
+++ b/src/main/java/cinebox/domain/auth/dto/KakaoProfile.java
@@ -1,0 +1,22 @@
+package cinebox.domain.auth.dto;
+
+public record KakaoProfile(
+		Long id,
+		String connected_at,
+		Properties properties,
+		KakaoAccount kakao_account
+) {
+	public record Properties(String nickname) {}
+	
+	public record KakaoAccount(
+			String email,
+			Boolean is_email_verified,
+			Boolean has_email,
+			Boolean profile_nickname_needs_agreement,
+			Boolean email_needs_agreement,
+			Boolean is_email_valid,
+			Profile profile
+	) {
+		public record Profile(String nickname, Boolean is_default_nickname) {}
+	}
+}

--- a/src/main/java/cinebox/domain/auth/dto/OAuthToken.java
+++ b/src/main/java/cinebox/domain/auth/dto/OAuthToken.java
@@ -1,0 +1,12 @@
+package cinebox.domain.auth.dto;
+
+public record OAuthToken(
+		String access_token,
+		String token_type,
+		String refresh_token,
+		int expires_in,
+		String scope,
+		int refresh_token_expires_in
+) {
+
+}

--- a/src/main/java/cinebox/domain/auth/dto/SignUpRequest.java
+++ b/src/main/java/cinebox/domain/auth/dto/SignUpRequest.java
@@ -3,6 +3,7 @@ package cinebox.domain.auth.dto;
 import java.time.LocalDate;
 
 import cinebox.common.enums.Gender;
+import cinebox.common.enums.PlatformType;
 import cinebox.common.enums.Role;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotNull;
@@ -34,7 +35,8 @@ public record SignUpRequest(
 		LocalDate birthDate,
 		
 		Gender gender,
-		Role role
+		Role role,
+		PlatformType platformType
 ) {
 
 }

--- a/src/main/java/cinebox/domain/auth/dto/SignUpRequest.java
+++ b/src/main/java/cinebox/domain/auth/dto/SignUpRequest.java
@@ -9,13 +9,14 @@ import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
+import jakarta.validation.groups.Default;
 
 public record SignUpRequest(
 		@NotNull(message = "아이디는 4자 이상 20자 이하여야 합니다.")
 		@Size(min = 4, max = 20, message = "아이디는 4자 이상 20자 이하여야 합니다.")
 		String identifier,
 		
-		@NotNull(message = "비밀번호는 8자 이상 20자 이하이어야 합니다.")
+		@NotNull(groups = Default.class, message = "비밀번호는 8자 이상 20자 이하이어야 합니다.")
 		@Size(min = 8, max = 20, message = "비밀번호는 8자 이상 20자 이하이어야 합니다.")
 		String password,
 		

--- a/src/main/java/cinebox/domain/auth/service/AuthService.java
+++ b/src/main/java/cinebox/domain/auth/service/AuthService.java
@@ -18,5 +18,5 @@ public interface AuthService {
 	// 로그아웃
 	void logout(HttpServletRequest request, HttpServletResponse response);
 
-	AuthResponse oAuthLogin(String accessCode, HttpServletResponse httpServletResponse);
+	Object oAuthLogin(String accessCode, HttpServletResponse httpServletResponse);
 }

--- a/src/main/java/cinebox/domain/auth/service/AuthService.java
+++ b/src/main/java/cinebox/domain/auth/service/AuthService.java
@@ -17,4 +17,6 @@ public interface AuthService {
 
 	// 로그아웃
 	void logout(HttpServletRequest request, HttpServletResponse response);
+
+	AuthResponse oAuthLogin(String accessCode, HttpServletResponse httpServletResponse);
 }

--- a/src/main/java/cinebox/domain/auth/service/AuthService.java
+++ b/src/main/java/cinebox/domain/auth/service/AuthService.java
@@ -12,11 +12,16 @@ public interface AuthService {
 	// 회원가입
 	UserResponse signup(SignUpRequest request);
 
+	// 카카오 회원가입
+	UserResponse kakaoSignup(SignUpRequest request);
+
 	// 로그인
 	AuthResponse login(AuthRequest request, HttpServletResponse response);
 
 	// 로그아웃
 	void logout(HttpServletRequest request, HttpServletResponse response);
 
+	// 카카오 로그인
 	Object oAuthLogin(String accessCode, HttpServletResponse httpServletResponse);
+
 }

--- a/src/main/java/cinebox/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/cinebox/domain/auth/service/AuthServiceImpl.java
@@ -52,12 +52,16 @@ public class AuthServiceImpl implements AuthService {
 	public UserResponse signup(SignUpRequest request) {
 		validateUniqueFields(request);
 
-        String encodedPassword = passwordEncoder.encode(request.password());
-        PlatformType platformType = request.platformType();
-        
-        if (request.platformType() == null) {
-        	platformType = PlatformType.LOCAL;
-        }
+		String encodedPassword = null;
+		PlatformType platformType = request.platformType();
+
+		if (request.platformType().equals(PlatformType.KAKAO)) {
+			encodedPassword = passwordEncoder.encode(java.util.UUID.randomUUID().toString());
+		} else {
+			platformType = PlatformType.LOCAL;
+			encodedPassword = passwordEncoder.encode(request.password());
+		}
+
 		User newUser = User.createUser(request, encodedPassword, platformType);
 
 		// ADMIN이 생성하는 계정이 아니라면 USER로 역할 고정

--- a/src/main/java/cinebox/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/cinebox/domain/auth/service/AuthServiceImpl.java
@@ -99,8 +99,18 @@ public class AuthServiceImpl implements AuthService {
 		PrincipalDetails principal = (PrincipalDetails) authentication.getPrincipal();
 		User user = principal.getUser();
 		
-		String accessToken = jwtTokenProvider.createAccessToken(user.getUserId(), user.getRole().name());
-		String refreshToken = jwtTokenProvider.createRefreshToken(user.getUserId(), user.getRole().name());
+		String accessToken = jwtTokenProvider.createAccessToken(
+				user.getUserId(),
+				user.getRole().name(),
+				user.getPlatformType(),
+				user.getIdentifier()
+		);
+		String refreshToken = jwtTokenProvider.createRefreshToken(
+				user.getUserId(),
+				user.getRole().name(),
+				user.getPlatformType(),
+				user.getIdentifier()
+		);
 		
 		TokenRedis tokenRedis = new TokenRedis(String.valueOf(user.getUserId()), accessToken, refreshToken);
 		tokenRedisRepository.save(tokenRedis);
@@ -135,8 +145,18 @@ public class AuthServiceImpl implements AuthService {
 		if (optionalUser.isPresent()) {
 			User user = optionalUser.get();
 			
-			String accessToken = jwtTokenProvider.createAccessToken(user.getUserId(), user.getRole().name());
-			String refreshToken = jwtTokenProvider.createRefreshToken(user.getUserId(), user.getRole().name());
+			String accessToken = jwtTokenProvider.createAccessToken(
+					user.getUserId(),
+					user.getRole().name(),
+					user.getPlatformType(),
+					user.getIdentifier()
+			);
+			String refreshToken = jwtTokenProvider.createRefreshToken(
+					user.getUserId(),
+					user.getRole().name(),
+					user.getPlatformType(),
+					user.getIdentifier()
+			);
 			
 			TokenRedis tokenRedis = new TokenRedis(String.valueOf(user.getUserId()), accessToken, refreshToken);
 			tokenRedisRepository.save(tokenRedis);

--- a/src/main/java/cinebox/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/cinebox/domain/auth/service/AuthServiceImpl.java
@@ -144,13 +144,13 @@ public class AuthServiceImpl implements AuthService {
 	}
 
 	private void validateUniqueFields(SignUpRequest request) {
-		if (userRepository.existsByIdentifier(request.identifier())) {
+		if (userRepository.existsByIdentifierAndPlatformType(request.identifier(), PlatformType.LOCAL)) {
 			throw DuplicatedIdentifierException.EXCEPTION;
 		}
-		if (userRepository.existsByEmail(request.email())) {
+		if (userRepository.existsByEmailAndPlatformType(request.email(), PlatformType.LOCAL)) {
 			throw DuplicatedEmailException.EXCEPTION;
 		}
-		if (userRepository.existsByPhone(request.phone())) {
+		if (userRepository.existsByPhoneAndPlatformType(request.phone(), PlatformType.LOCAL)) {
 			throw DuplicatedPhoneException.EXCEPTION;
 		}
 	}

--- a/src/main/java/cinebox/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/cinebox/domain/auth/service/AuthServiceImpl.java
@@ -72,7 +72,7 @@ public class AuthServiceImpl implements AuthService {
 	@Override
 	@Transactional
 	public AuthResponse login(AuthRequest request, HttpServletResponse response) {
-		UsernamePasswordAuthenticationToken token = new UsernamePasswordAuthenticationToken(request.getIdentifier(), request.getPassword());
+		UsernamePasswordAuthenticationToken token = new UsernamePasswordAuthenticationToken(request.identifier(), request.password());
 		Authentication authentication = authenticationManager.authenticate(token);
 		
 		PrincipalDetails principal = (PrincipalDetails) authentication.getPrincipal();

--- a/src/main/java/cinebox/domain/user/dto/UserResponse.java
+++ b/src/main/java/cinebox/domain/user/dto/UserResponse.java
@@ -3,6 +3,7 @@ package cinebox.domain.user.dto;
 import java.time.LocalDate;
 
 import cinebox.common.enums.Gender;
+import cinebox.common.enums.PlatformType;
 import cinebox.common.enums.Role;
 import cinebox.domain.user.entity.User;
 
@@ -15,7 +16,8 @@ public record UserResponse(
 	    Integer age,
 	    LocalDate birthDate,
 	    Gender gender,
-	    Role role
+	    Role role,
+	    PlatformType platform
 ) {
 	public static UserResponse from(User user) {
         return new UserResponse(
@@ -27,7 +29,8 @@ public record UserResponse(
                 user.getAge(),
                 user.getBirthDate(),
                 user.getGender(),
-                user.getRole()
+                user.getRole(),
+                user.getPlatformType()
         );
 	}
 }

--- a/src/main/java/cinebox/domain/user/entity/User.java
+++ b/src/main/java/cinebox/domain/user/entity/User.java
@@ -136,7 +136,7 @@ public class User extends BaseTimeEntity {
 				.phone(request.phone())
 				.birthDate(request.birthDate())
 				.gender(request.gender())
-				.role(request.role())
+				.role(request.role() != null ? request.role() : Role.USER)
 				.platformType(platformType)
 				.build();
 	}

--- a/src/main/java/cinebox/domain/user/entity/User.java
+++ b/src/main/java/cinebox/domain/user/entity/User.java
@@ -37,6 +37,7 @@ import lombok.NoArgsConstructor;
 @Table(
 		name = "user",
 		uniqueConstraints = {
+				@UniqueConstraint(columnNames = {"identifier", "platform_type"}),
 				@UniqueConstraint(columnNames = {"email", "platform_type"}),
 				@UniqueConstraint(columnNames = {"phone", "platform_type"})
 		})
@@ -52,10 +53,10 @@ public class User extends BaseTimeEntity {
 	@Column(name = "user_id")
 	private Long userId;
 
-	@Column(nullable = false, unique = true)
+	@Column(nullable = false)
 	private String identifier;
 
-	@Column(nullable = false, unique = true)
+	@Column(nullable = false)
 	private String email;
 
 	@Column(nullable = false)
@@ -64,7 +65,7 @@ public class User extends BaseTimeEntity {
 	@Column(nullable = false)
 	private String name;
 
-	@Column(nullable = false, unique = true)
+	@Column(nullable = false)
 	private String phone;
 
 	@Column(name = "birth_date")

--- a/src/main/java/cinebox/domain/user/entity/User.java
+++ b/src/main/java/cinebox/domain/user/entity/User.java
@@ -9,6 +9,7 @@ import org.hibernate.annotations.SQLRestriction;
 
 import cinebox.common.entity.BaseTimeEntity;
 import cinebox.common.enums.Gender;
+import cinebox.common.enums.PlatformType;
 import cinebox.common.enums.Role;
 import cinebox.domain.auth.dto.SignUpRequest;
 import cinebox.domain.booking.entity.Booking;
@@ -26,13 +27,19 @@ import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "user")
+@Table(
+		name = "user",
+		uniqueConstraints = {
+				@UniqueConstraint(columnNames = {"email", "platform_type"}),
+				@UniqueConstraint(columnNames = {"phone", "platform_type"})
+		})
 @Getter
 @Builder
 @AllArgsConstructor
@@ -80,6 +87,10 @@ public class User extends BaseTimeEntity {
 	@Column(nullable = false)
 	@Enumerated(EnumType.STRING)
 	private Role role;
+	
+	@Column(nullable = false, name = "platform_type")
+	@Enumerated(EnumType.STRING)
+	private PlatformType platformType = PlatformType.LOCAL;
 
 	@OneToMany(mappedBy = "user")
 	private List<Booking> bookings = new ArrayList<>();
@@ -115,7 +126,7 @@ public class User extends BaseTimeEntity {
 		this.isDeleted = false;
 	}
 
-	public static User createUser(SignUpRequest request, String encodedPassword) {
+	public static User createUser(SignUpRequest request, String encodedPassword, PlatformType platformType) {
 		return User.builder()
 				.identifier(request.identifier())
 				.password(encodedPassword)
@@ -125,6 +136,7 @@ public class User extends BaseTimeEntity {
 				.birthDate(request.birthDate())
 				.gender(request.gender())
 				.role(request.role())
+				.platformType(platformType)
 				.build();
 	}
 }

--- a/src/main/java/cinebox/domain/user/repository/UserRepository.java
+++ b/src/main/java/cinebox/domain/user/repository/UserRepository.java
@@ -1,6 +1,5 @@
 package cinebox.domain.user.repository;
 
-import java.util.Collection;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -8,23 +7,22 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import cinebox.common.enums.PlatformType;
 import cinebox.domain.user.entity.User;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
-	boolean existsByUserId(Long userId);
-	Optional<User> findByIdentifierAndIsDeletedFalse(String identifier);
-	Optional<User> findByUserIdAndIsDeletedFalse(Long userId);
-	Collection<User> findAllByIsDeletedFalse();
 	Optional<User> findByIdentifier(String identifier);
-	
+
 	@Query(value = "SELECT * FROM user WHERE user_id = :userId", nativeQuery = true)
 	Optional<User> findByIdIncludingDeleted(@Param("userId") Long userId);
 
 	@Query(value = "SELECT * FROM user WHERE user_id = :userId AND is_deleted = true", nativeQuery = true)
 	Optional<User> findDeletedByUserId(@Param("userId") Long userId);
-	
+
 	boolean existsByIdentifier(String identifier);
 	boolean existsByEmail(String email);
 	boolean existsByPhone(String phone);
+
+	Optional<User> findByEmailAndPlatformType(String email, PlatformType kakao);
 }

--- a/src/main/java/cinebox/domain/user/repository/UserRepository.java
+++ b/src/main/java/cinebox/domain/user/repository/UserRepository.java
@@ -25,4 +25,12 @@ public interface UserRepository extends JpaRepository<User, Long> {
 	boolean existsByPhone(String phone);
 
 	Optional<User> findByEmailAndPlatformType(String email, PlatformType kakao);
+
+	boolean existsByIdentifierAndPlatformType(String identifier, PlatformType local);
+
+	boolean existsByEmailAndPlatformType(String email, PlatformType local);
+
+	boolean existsByPhoneAndPlatformType(String phone, PlatformType local);
+
+	Optional<User> findByIdentifierAndPlatformType(String username, PlatformType local);
 }

--- a/src/main/java/cinebox/security/config/RestTempateConfig.java
+++ b/src/main/java/cinebox/security/config/RestTempateConfig.java
@@ -1,0 +1,24 @@
+package cinebox.security.config;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.converter.FormHttpMessageConverter;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTempateConfig {
+	@Bean
+	public RestTemplate restTemplate() {
+		RestTemplate restTemplate = new RestTemplate();
+
+		List<HttpMessageConverter<?>> messageConverters = new ArrayList<>();
+		messageConverters.add(new FormHttpMessageConverter());
+		restTemplate.setMessageConverters(messageConverters);
+
+		return restTemplate;
+	}
+}

--- a/src/main/java/cinebox/security/config/SecurityConfig.java
+++ b/src/main/java/cinebox/security/config/SecurityConfig.java
@@ -47,13 +47,7 @@ public class SecurityConfig {
 		http.csrf(csrf -> csrf.disable()).addFilterBefore(corsFilter, UsernamePasswordAuthenticationFilter.class)
 				.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 				.authorizeHttpRequests(auth -> auth
-
-						.requestMatchers("/images/**", "/css/**", "/js/**").permitAll()
-						.requestMatchers("/api/auth/**", "/api/bookings/**", "/api/payments", "/bookings/payment-test")
-						.permitAll().requestMatchers("/", "/signup/**", "/mypage/**").permitAll()
-						.requestMatchers("/admin").hasAuthority("ROLE_ADMIN")
-
-						.anyRequest().authenticated())
+						.requestMatchers("/**").permitAll())
 				.addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider),
 						UsernamePasswordAuthenticationFilter.class);
 		return http.build();

--- a/src/main/java/cinebox/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/cinebox/security/jwt/JwtTokenProvider.java
@@ -88,7 +88,7 @@ public class JwtTokenProvider {
 	public Authentication getAuthentication(String token) {
 		DecodedJWT decodedJWT = JWT.require(Algorithm.HMAC256(secretKey)).build().verify(token);
 		Long userId = decodedJWT.getClaim("user_id").asLong();
-		cinebox.domain.user.entity.User user = userRepository.findByUserIdAndIsDeletedFalse(userId)
+		cinebox.domain.user.entity.User user = userRepository.findById(userId)
 				.orElseThrow(() -> NotFoundUserException.EXCEPTION);
 		PrincipalDetails principalDetails = new PrincipalDetails(user);
 		return new UsernamePasswordAuthenticationToken(principalDetails, "", principalDetails.getAuthorities());

--- a/src/main/java/cinebox/security/service/PrincipalDetailsService.java
+++ b/src/main/java/cinebox/security/service/PrincipalDetailsService.java
@@ -17,9 +17,15 @@ public class PrincipalDetailsService implements UserDetailsService {
 
     @Override
     public PrincipalDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-
-    	User user = userRepository.findByIdentifierAndPlatformType(username, PlatformType.LOCAL).orElseThrow(() -> NotFoundUserException.EXCEPTION);
+    	User user = userRepository.findByIdentifierAndPlatformType(username, PlatformType.LOCAL)
+    			.orElseThrow(() -> NotFoundUserException.EXCEPTION);
         return new PrincipalDetails (user);
+    }
+
+    public PrincipalDetails loadUserByUsernameAndPlatform(String identifier, PlatformType platformType) throws UsernameNotFoundException {
+        User user = userRepository.findByIdentifierAndPlatformType(identifier, platformType)
+                .orElseThrow(() -> NotFoundUserException.EXCEPTION);
+        return new PrincipalDetails(user);
     }
 
 }

--- a/src/main/java/cinebox/security/service/PrincipalDetailsService.java
+++ b/src/main/java/cinebox/security/service/PrincipalDetailsService.java
@@ -17,7 +17,7 @@ public class PrincipalDetailsService implements UserDetailsService {
     @Override
     public PrincipalDetails loadUserByUsername(String username) throws UsernameNotFoundException {
 
-    	User user = userRepository.findByIdentifierAndIsDeletedFalse(username).orElseThrow(() -> NotFoundUserException.EXCEPTION);
+    	User user = userRepository.findByIdentifier(username).orElseThrow(() -> NotFoundUserException.EXCEPTION);
         return new PrincipalDetails (user);
     }
 

--- a/src/main/java/cinebox/security/service/PrincipalDetailsService.java
+++ b/src/main/java/cinebox/security/service/PrincipalDetailsService.java
@@ -4,6 +4,7 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
+import cinebox.common.enums.PlatformType;
 import cinebox.common.exception.user.NotFoundUserException;
 import cinebox.domain.user.entity.User;
 import cinebox.domain.user.repository.UserRepository;
@@ -17,7 +18,7 @@ public class PrincipalDetailsService implements UserDetailsService {
     @Override
     public PrincipalDetails loadUserByUsername(String username) throws UsernameNotFoundException {
 
-    	User user = userRepository.findByIdentifier(username).orElseThrow(() -> NotFoundUserException.EXCEPTION);
+    	User user = userRepository.findByIdentifierAndPlatformType(username, PlatformType.LOCAL).orElseThrow(() -> NotFoundUserException.EXCEPTION);
         return new PrincipalDetails (user);
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

#31 #100 

## 📝작업 내용

- OAuth 및 카카오 로그인 구현
   - 로그인 시 등록 유저는 로그인 처리 (토큰 발급)
   - 로그인 시 미등록 유저는 401 에러를 반환해 프론트에서 회원가입 진행
- PlatformType Enum을 통해 플랫폼이 다르면 같은 ID를 사용 가능하게 변경
- PlatformType에 따른 인증/인가 구분
   - 동일한 Identifier를 가졌을 때 하나의 플랫폼으로만 로그인 되는 이슈가 있었음 (#100)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
