### PR TITLE
Fix(#102): Redis 키스페이스 이벤트 설정 수정

### DIFF
--- a/src/main/java/cinebox/security/config/RedisRepositoryConfig.java
+++ b/src/main/java/cinebox/security/config/RedisRepositoryConfig.java
@@ -17,7 +17,9 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 import cinebox.domain.auth.entity.TokenRedis;
 
 @Configuration
-@EnableRedisRepositories(enableKeyspaceEvents = RedisKeyValueAdapter.EnableKeyspaceEvents.ON_STARTUP)
+@EnableRedisRepositories(
+		enableKeyspaceEvents = RedisKeyValueAdapter.EnableKeyspaceEvents.ON_STARTUP,
+		keyspaceNotificationsConfigParameter = "")
 public class RedisRepositoryConfig {
 	@Value("${spring.data.redis.host}")
 	private String host;


### PR DESCRIPTION
## #️⃣연관된 이슈

#102 

## 📝작업 내용

- AWS ElastiCache와의 호환성을 위해 keyspace notifications 비활성화
- ElastiCache에서 인식되지 않는 CONFIG 명령어로 인한 애플리케이션 시작 실패 문제 해결

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
